### PR TITLE
Remove jar dependency for taglib

### DIFF
--- a/conf/cms-web.xml
+++ b/conf/cms-web.xml
@@ -313,10 +313,6 @@
 	</error-page>
 
 	<taglib>
-		<taglib-uri>webwork</taglib-uri>
-		<taglib-location>/WEB-INF/lib/webwork.jar</taglib-location>
-	</taglib>
-	<taglib>
 		<taglib-uri>infoglue-common</taglib-uri>
 		<taglib-location>/WEB-INF/tld/infoglue-common.tld</taglib-location>
 	</taglib>

--- a/conf/deliver-web.xml
+++ b/conf/deliver-web.xml
@@ -284,11 +284,6 @@
 	</error-page>
 	
 	<taglib>
-		<taglib-uri>webwork</taglib-uri>
-		<taglib-location>/WEB-INF/lib/webwork.jar</taglib-location>
-	</taglib>
-	
-	<taglib>
 	  <taglib-uri>http://jakarta.apache.org/taglibs/mailer-1.1</taglib-uri>
 	  <taglib-location>/WEB-INF/tld/taglibs-mailer.tld</taglib-location>
 	</taglib>


### PR DESCRIPTION
Remove webwork dependency for webwork taglib as it is already defined into its own jar.
So that we won't have problem if webwork.jar has its name changed. With maven all jar are suffixed with their version, so we shouldn't have hardcoded jar name.
