### PR TITLE
Fixed useLanguageFallback functionality to propertyValue

### DIFF
--- a/conf/tld/infoglue-structure.tld
+++ b/conf/tld/infoglue-structure.tld
@@ -373,6 +373,11 @@
             <required>false</required>
             <rtexprvalue>false</rtexprvalue>
         </attribute>
+		<attribute>
+			<name>useLanguageFallback</name>
+			<required>false</required>
+			<rtexprvalue>false</rtexprvalue>
+		</attribute>
     </tag>
 
 	<tag>

--- a/src/java/org/infoglue/deliver/taglib/structure/ComponentPropertyValueTag.java
+++ b/src/java/org/infoglue/deliver/taglib/structure/ComponentPropertyValueTag.java
@@ -147,5 +147,8 @@ public class ComponentPropertyValueTag extends ComponentLogicTag
     {
         this.parseToMap = parseToMap;
     }
-
+	
+	public void setUseLanguageFallback(boolean useLanguageFallback){
+    	this.useLanguageFallback = useLanguageFallback;
+    }
 }


### PR DESCRIPTION
Added the missing usage of useLanguageFallback to one of the
getPropertyValue() and a setter in ComponentPropertyValueTag and the
corresponding tld
