### PR TITLE
Updates structure and fixes lingering indicator

### DIFF
--- a/src/webapp/cms/cmstool/adminEmbla.vm
+++ b/src/webapp/cms/cmstool/adminEmbla.vm
@@ -307,6 +307,5 @@
 	    </div>
 	</div>
 	
-	<div id="loadingIndicator"></div>
 </body>
-</html> 
+</html>

--- a/src/webapp/cms/structuretool/v3/viewStructureTool.vm
+++ b/src/webapp/cms/structuretool/v3/viewStructureTool.vm
@@ -14,6 +14,7 @@
 	<script type="text/javascript">
 		var currentSiteNodeId;
 		var currentRepositoryId;
+		var indicator;
 		
 		function setPageContext(siteNodeId, repositoryId)
 		{
@@ -30,12 +31,20 @@
 		function openUrlInWorkArea(url)
 		{
 			//alert("url:" + url);
+			if (indicator)
+			{
+				indicator.display();
+			}
 			document.getElementById("workIframe").src = url;
 		}
 	
 		function refreshWorkSurface()
 		{
 			//alert("refreshWorkSurface");
+			if (indicator)
+			{
+				indicator.display();
+			}
 			$("#workIframe").get(0).contentDocument.location.reload();
 		}
 		
@@ -95,7 +104,9 @@
 	   		window.onresize = function() {
 	   			resize(false);
    			}
-			
+
+			indicator = LoadingIndicator("#loadingIndicator", "#workIframe");
+
 			$("#toolsColumn").resizable({ 
 				handles: 'e',
 				maxWidth: 460,
@@ -306,6 +317,8 @@
 <div id="contextMenuDiv"></div>
 
 <div id="menuOverlayDiv"></div>
+
+<div id="loadingIndicator"></div>
 
 </body>
 </html>

--- a/src/webapp/cms/structuretool/v3/viewStructureToolMenu.vm
+++ b/src/webapp/cms/structuretool/v3/viewStructureToolMenu.vm
@@ -64,9 +64,7 @@
 		function openUrlInWorkArea(url, titel)
 		{
 			//alert("openUrlInWorkArea:" + url);
-			
-			top.displayLoadingIndicator(); 
-			
+
 			if(parent.openUrlInWorkArea)
 				parent.openUrlInWorkArea(url, titel, 'structure', "$ui.getString("tool.common.pageTabLabelPrefix")");
 		}

--- a/src/webapp/css/admin.css
+++ b/src/webapp/css/admin.css
@@ -323,12 +323,13 @@ iframe.inactiveTool {
 	background-repeat: no-repeat;
 	background-position: 10px 9px;
 }
-#loadingIndicator {
+
+.loadingIndicator {
 	width: 64px;
 	height: 32px;
 	position: absolute;
 	right: 30px;
-	top: 100px;
+	top: 62px;
 	background-image: url("images/v3/loadingAnimation.gif");
 	background-repeat: no-repeat;
 }

--- a/src/webapp/preview/pageComponentEditorHeader.vm
+++ b/src/webapp/preview/pageComponentEditorHeader.vm
@@ -199,14 +199,6 @@
           	$("#tempDraggable").remove();
         });
 	});
-	
-	//-----------------------------------------------------
-	// Hide the loading animation when the page has loaded 
-	//----------------------------------------------------- 
-
-	$(document).ready(function() {
-		top.hideLoadingIndicator();
-	});
 -->
 </script>
 

--- a/src/webapp/script/embla/admin.js
+++ b/src/webapp/script/embla/admin.js
@@ -263,3 +263,37 @@ function syncWithTree(path, repositoryId, targetFrame)
 {
 	document.getElementById(targetFrame).contentWindow.syncWithTree(path, repositoryId);
 }
+
+/**
+ * Constructs a loading indicator from the given DOM element (preferably a DIV).
+ */
+var LoadingIndicator = function(indicator, workarea) {
+	var $indicator = $(indicator);
+
+	if ($indicator.length === 0) {
+		throw "No indicator container found";
+	}
+
+	$indicator.hide();
+	$indicator.addClass("loadingIndicator");
+
+	if (workarea) {
+		$(workarea).load(function() {
+			hide();
+		});
+	}
+
+	/** Displays the loading indicator.
+	 *  If a workarea was provided to the loading indicator the indicator
+	 *  will be hidden automatically the next time the workarea trigger
+	 *  its load-event.
+	 *  */
+	this.display = function(timeoutTime) {
+		$indicator.show();
+	};
+	/** Hides the loading indicator. */
+	this.hide = function() {
+		$indicator.hide();
+	}
+	return this;
+};

--- a/src/webapp/script/embla/infoglue.js
+++ b/src/webapp/script/embla/infoglue.js
@@ -509,17 +509,3 @@ function hideNotification()
 	notificationIsHot = false; 
 	$("#popupAlertMessageDiv").css("margin-top", "35px");
 }
-
-//-------------------------------------------------------
-// Display a loading indicator when something is loading
-//-------------------------------------------------------
-
-function displayLoadingIndicator()
-{ 
-	$("#loadingIndicator").show();
-}
-
-function hideLoadingIndicator()
-{
-	$("#loadingIndicator").hide();
-}


### PR DESCRIPTION
Wrappes the indicator logic in a JavaScript object and moves the
HTML and show/hide-code to the Structure tool. By moving the code
we can trigger in the load-event of the work-iframe and by doing so
prevent the lingering indicator. The indicator is no longer visible
in the other tools.
