### PR TITLE
Adds new handling of assets in disk

### DIFF
--- a/src/java/org/infoglue/cms/controllers/kernel/impl/simple/ContentVersionController.java
+++ b/src/java/org/infoglue/cms/controllers/kernel/impl/simple/ContentVersionController.java
@@ -2150,6 +2150,39 @@ public class ContentVersionController extends BaseController
 		return contentVersionVO;
     }
 
+	public ContentVersionVO getSecondLatestActiveContentVersionVO(Integer contentId, Integer languageId, boolean isActive, Database db) throws SystemException, Bug, Exception
+	{
+		ContentVersionVO contentVersionVO = null;
+
+		OQLQuery oql = db.getOQLQuery( "SELECT cv FROM org.infoglue.cms.entities.content.impl.simple.SmallContentVersionImpl cv WHERE cv.contentId = $1 AND cv.languageId = $2 AND cv.isActive = $3 AND cv.stateId >= $4 ORDER BY cv.contentVersionId desc");
+		oql.bind(contentId);
+		oql.bind(languageId);
+		oql.bind(new Boolean(true));
+		oql.bind(CmsPropertyHandler.getOperatingMode());
+
+		QueryResults results = oql.execute(Database.ReadOnly);
+
+		if (results.hasMore())
+		{
+			results.next();
+			logger.debug("found first latest content version");
+			if (results.hasMore())
+			{
+				ContentVersion contentVersion = (ContentVersion)results.next();
+				if (logger.isInfoEnabled())
+				{
+					logger.info("found second latest content version:" + contentVersion.getValueObject());
+				}
+				contentVersionVO = contentVersion.getValueObject();
+			}
+		}
+
+		results.close();
+		oql.close();
+
+		return contentVersionVO;
+	}
+
 
 	/**
 	 * This method deletes the relation to a digital asset - not the asset itself.

--- a/src/java/org/infoglue/cms/util/CmsPropertyHandler.java
+++ b/src/java/org/infoglue/cms/util/CmsPropertyHandler.java
@@ -925,7 +925,7 @@ public class CmsPropertyHandler
 
 	public static String getDisableAssetDeletionInLiveThread()
 	{
-	    return getServerNodeProperty("getDisableAssetDeletionInLiveThread", true, "false");
+	    return getServerNodeProperty("disableAssetDeletionInLiveThread", true, "false");
 	}
 
 	public static String getExtranetCookieTimeout()

--- a/src/java/org/infoglue/deliver/util/AssetUpdatingThread.java
+++ b/src/java/org/infoglue/deliver/util/AssetUpdatingThread.java
@@ -1,0 +1,140 @@
+/**
+ * 
+ */
+package org.infoglue.deliver.util;
+
+import java.io.File;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.log4j.Logger;
+import org.exolab.castor.jdo.Database;
+import org.infoglue.cms.controllers.kernel.impl.simple.CastorDatabaseService;
+import org.infoglue.cms.controllers.kernel.impl.simple.ContentVersionController;
+import org.infoglue.cms.controllers.kernel.impl.simple.DigitalAssetController;
+import org.infoglue.cms.entities.content.ContentVersionVO;
+import org.infoglue.cms.entities.content.DigitalAssetVO;
+import org.infoglue.cms.util.CmsPropertyHandler;
+
+class AssetUpdatingThread extends Thread
+{
+	private static final Logger logger = Logger.getLogger(AssetUpdatingThread.class);
+	private String contentVersionIdString;
+
+	AssetUpdatingThread(String contentVersionIdString)
+	{
+		this.contentVersionIdString = contentVersionIdString;
+	}
+
+	@SuppressWarnings("static-access")
+	@Override
+	public void run()
+	{
+		Database db = null;
+		try
+		{
+			db = CastorDatabaseService.getDatabase();
+			CacheController.beginTransaction(db);
+
+			// Setup
+			Integer contentVersionId = new Integer(contentVersionIdString);
+			ContentVersionVO contentVersionVO = ContentVersionController.getContentVersionController().getContentVersionVOWithId(contentVersionId, db);
+			int operationMode = Integer.parseInt(CmsPropertyHandler.getOperatingMode());
+			if (contentVersionVO.getStateId() < operationMode)
+			{
+				logger.debug("Updated version had a to low state. State: " + contentVersionVO.getStateId() + ". Operation mode: " + operationMode);
+			}
+			else
+			{
+				Integer contentId = contentVersionVO.getContentId();
+				Integer languageId = contentVersionVO.getLanguageId();
+				Set<Integer> existingAssetIds = new HashSet<Integer>();
+
+				logger.info("Starting asset on disc clean for ContentVersion. Id: " + contentId);
+
+				// Get stuff from previous version
+				ContentVersionVO previousContentVersionVO = ContentVersionController.getContentVersionController().getSecondLatestActiveContentVersionVO(contentId, languageId, false, db);
+				if (logger.isInfoEnabled())
+				{
+					logger.info("Found previous content version for cache cleaning. ContentVersion.id:" + (previousContentVersionVO == null ? "null" : previousContentVersionVO.getContentVersionId()));
+				}
+				List<DigitalAssetVO> previousDigitalAssets = DigitalAssetController.getController().getDigitalAssetVOList(previousContentVersionVO.getContentVersionId(), db);
+				for (DigitalAssetVO digitalAssetVO : previousDigitalAssets)
+				{
+					if (logger.isDebugEnabled())
+					{
+						logger.debug("Adding digital asset to previous assets. DigitalAsset.id: " + digitalAssetVO.getDigitalAssetId());
+					}
+					existingAssetIds.add(digitalAssetVO.getDigitalAssetId());
+				}
+
+				if (logger.isInfoEnabled())
+				{
+					logger.info("existingAssets: " + existingAssetIds);
+				}
+
+				// Handling assets in current version
+				List<DigitalAssetVO> digitalAssetVOs = DigitalAssetController.getDigitalAssetVOList(contentVersionId, db);
+				if (digitalAssetVOs.size() == 0)
+				{
+					logger.info("ContentVersion had no assets so we leave things as they are. ContentVersion.id: " + contentVersionIdString);
+				}
+				else
+				{
+					for (DigitalAssetVO digitalAssetVO : digitalAssetVOs)
+					{
+						if (logger.isDebugEnabled())
+						{
+							logger.debug("Checking DigitalAsset.id: " + digitalAssetVO.getDigitalAssetId() + " for ContentVersion.id: " + contentVersionIdString);
+						}
+						boolean wasOldAsset = existingAssetIds.remove(digitalAssetVO.getDigitalAssetId());
+						if (wasOldAsset)
+						{
+							logger.debug("Asset still exists");
+						}
+
+						// Check if we should update file on disc
+						File currentAssetFile = DigitalAssetController.getController().getAssetFile(digitalAssetVO, contentId, languageId, db);
+						if (currentAssetFile != null)
+						{
+							logger.debug("File is currently stored on disc, let's update!. File: " + currentAssetFile.getAbsolutePath());
+							File assetFolder = DigitalAssetController.getController().getAssetFolderFile(digitalAssetVO, contentId, languageId, db);
+							String assetFilename = DigitalAssetController.getController().getAssetFileName(digitalAssetVO, contentId, languageId, db);
+							DigitalAssetController.getController().dumpDigitalAsset(digitalAssetVO, assetFilename, assetFolder.getAbsolutePath(), true, db);
+						}
+					}
+				}
+
+				logger.info("Number of assets to remove after cache clean: " + existingAssetIds.size());
+				for (Integer digitalAssetId : existingAssetIds)
+				{
+					DigitalAssetVO digitalAssetVO = DigitalAssetController.getController().getDigitalAssetVOWithId(digitalAssetId, db);
+					File assetFile = DigitalAssetController.getController().getAssetFile(digitalAssetVO, contentId, languageId, db);
+					if (assetFile != null)
+					{
+						logger.debug("Found asset file to remove. File: " + assetFile.getAbsolutePath());
+						boolean success = assetFile.delete();
+						if (logger.isDebugEnabled() && success)
+						{
+							logger.debug("Successfully deleted file. File: " + assetFile.getAbsolutePath());
+						}
+					}
+				}
+			}
+
+			CacheController.commitTransaction(db);
+		}
+		catch (NumberFormatException nex)
+		{
+			CacheController.rollbackTransaction(db);
+			logger.warn("Failed to parse integer in asset clean thread. Message: " + nex);
+		}
+		catch (Throwable ex)
+		{
+			CacheController.rollbackTransaction(db);
+			logger.error("Error when cleaning assets from disc for ContentVersion.id: " + contentVersionIdString + ". Message: " + ex.getMessage());
+			logger.warn("Error when cleaning assets from disc for ContentVersion.id: " + contentVersionIdString, ex);
+		}
+	}
+}

--- a/src/java/org/infoglue/deliver/util/CacheController.java
+++ b/src/java/org/infoglue/deliver/util/CacheController.java
@@ -32,6 +32,7 @@ import java.io.StringReader;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -75,7 +76,9 @@ import org.infoglue.cms.controllers.kernel.impl.simple.SiteNodeController;
 import org.infoglue.cms.controllers.kernel.impl.simple.SiteNodeVersionController;
 import org.infoglue.cms.entities.content.ContentCategoryVO;
 import org.infoglue.cms.entities.content.ContentVO;
+import org.infoglue.cms.entities.content.ContentVersion;
 import org.infoglue.cms.entities.content.ContentVersionVO;
+import org.infoglue.cms.entities.content.DigitalAsset;
 import org.infoglue.cms.entities.content.SmallestContentVersionVO;
 import org.infoglue.cms.entities.content.impl.simple.ContentCategoryImpl;
 import org.infoglue.cms.entities.content.impl.simple.ContentImpl;
@@ -146,6 +149,7 @@ import org.infoglue.cms.entities.workflow.impl.simple.ConsequenceImpl;
 import org.infoglue.cms.entities.workflow.impl.simple.EventImpl;
 import org.infoglue.cms.entities.workflow.impl.simple.WorkflowDefinitionImpl;
 import org.infoglue.cms.entities.workflow.impl.simple.WorkflowImpl;
+import org.infoglue.cms.exception.Bug;
 import org.infoglue.cms.exception.SystemException;
 import org.infoglue.cms.io.FileHelper;
 import org.infoglue.cms.security.InfoGlueAuthenticationFilter;
@@ -157,6 +161,7 @@ import org.infoglue.deliver.applications.databeans.CacheEvictionBean;
 import org.infoglue.deliver.applications.databeans.DatabaseWrapper;
 import org.infoglue.deliver.cache.PageCacheHelper;
 import org.infoglue.deliver.controllers.kernel.impl.simple.ContentDeliveryController;
+import org.infoglue.deliver.controllers.kernel.impl.simple.DigitalAssetDeliveryController;
 import org.infoglue.deliver.controllers.kernel.impl.simple.NodeDeliveryController;
 import org.infoglue.deliver.invokers.PageInvoker;
 import org.infoglue.deliver.portal.ServletConfigContainer;
@@ -3320,6 +3325,8 @@ public class CacheController extends Thread
 									    	logger.info("After flushGroup2...");
 							    		}
 								    	//}
+
+										new AssetUpdatingThread(entityId).start();
 							    	}
 							    	catch(SystemException se)
 							    	{
@@ -4999,7 +5006,7 @@ public class CacheController extends Thread
 	 * Ends a transaction on the named database
 	 */
 	
-    private static void commitTransaction(Database db) throws SystemException
+    static void commitTransaction(Database db) throws SystemException
 	{
 		try
 		{


### PR DESCRIPTION
With the persitent asset name feature introduced in IG3 the updating of assets
on disk stopped working. This commit fixes this by introducing a update asset
thread that triggers on cache clearings.
