### PR TITLE
Hides metainfo in context meny based on InterPoint

### DIFF
--- a/src/webapp/cms/contenttool/v3/viewContentToolContextMenu.vm
+++ b/src/webapp/cms/contenttool/v3/viewContentToolContextMenu.vm
@@ -12,7 +12,9 @@
     <li><a id="delete" href="javascript:void(0);" class="delete">$ui.getString("tool.contenttool.toolbarV3.deleteContentLabel")</a></li>
     #end
     <li><a id="move" href="javascript:void(0);" class="moveContent">$ui.getString("tool.contenttool.toolbarV3.moveContentLabel")</a></li>
+    #if($this.hasAccessTo("ToolTabsAndButtons.ContentToolbarContentPropertiesButton", true, false, true))
     <li><a id="properties" href="javascript:void(0);" class="properties">$ui.getString("tool.contenttool.toolbarV3.editContentMetaInfoLabel")</a></li>
+    #end
     <li><a id="publish" href="javascript:void(0);" class="publish">$ui.getString("tool.contenttool.toolbarV3.publishContentLabel")</a></li>
     #*
     #if($contentVO.isBranch)


### PR DESCRIPTION
The IP ToolTabsAndButtons.ContentToolbarContentPropertiesButton was used
to hide the metainfo option in  the tooblar but not in the context menu
for folders in Content tool. This has been fixed now so both menus use the
IP.
