### PR TITLE
Adds a general settings field in app. settings

### DIFF
--- a/conf/tld/infoglue-management.tld
+++ b/conf/tld/infoglue-management.tld
@@ -1054,4 +1054,26 @@
             <rtexprvalue>false</rtexprvalue>
         </attribute>
 	</tag>
+
+	<tag>
+		<name>generalSetting</name>
+		<tagclass>org.infoglue.deliver.taglib.management.GeneralSettingTag</tagclass>
+		<bodycontent>empty</bodycontent>
+		<info>Gets a value from the general settings. TemplateController#getGeneralSetting()</info>
+		<attribute>
+			<name>id</name>
+			<required>false</required>
+			<rtexprvalue>false</rtexprvalue>
+		</attribute>
+		<attribute>
+			<name>key</name>
+			<required>true</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<name>default</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+	</tag>
 </taglib>

--- a/src/java/org/infoglue/cms/applications/PresentationStrings_en.properties
+++ b/src/java/org/infoglue/cms/applications/PresentationStrings_en.properties
@@ -2011,3 +2011,6 @@ tool.structuretool.createSiteNode.metaFields=Meta data
 entity.Redirect.siteNode.label=Site node ID
 entity.Redirect.language.label=Language
 entity.ServerNode.property.redirectUsingSystemRedirect.label=Redirect users if there are a system redirect rule.
+
+entity.ServerNode.property.generalSettings.label=Custom settings that are defined for the entire application. See Java's documentation of the Properties class for formatting information.
+entity.ServerNode.property.workingGeneralSettings.label=Complementing custom settings that are only enabled in working mode (deliverWorking). Overwrites settings with the same keys in the main list.

--- a/src/java/org/infoglue/cms/applications/PresentationStrings_fr.properties
+++ b/src/java/org/infoglue/cms/applications/PresentationStrings_fr.properties
@@ -1979,3 +1979,6 @@ tool.structuretool.createSiteNode.metaFields=Meta data
 entity.Redirect.siteNode.label=Site node ID
 entity.Redirect.language.label=Language
 entity.ServerNode.property.redirectUsingSystemRedirect.label=Redirect users if there are a system redirect rule.
+
+entity.ServerNode.property.generalSettings.label=Custom settings that are defined for the entire application. See Java's documentation of the Properties class for formatting information.
+entity.ServerNode.property.workingGeneralSettings.label=Complementing custom settings that are only enabled in working mode (deliverWorking). Overwrites settings with the same keys in the main list.

--- a/src/java/org/infoglue/cms/applications/PresentationStrings_sv.properties
+++ b/src/java/org/infoglue/cms/applications/PresentationStrings_sv.properties
@@ -1978,3 +1978,6 @@ tool.structuretool.createSiteNode.metaFields=Metadata
 entity.Redirect.siteNode.label=Nod-ID
 entity.Redirect.language.label=Språk
 entity.ServerNode.property.redirectUsingSystemRedirect.label=Omdirigera användaren om det finns en system redirect.
+
+entity.ServerNode.property.generalSettings.label=Egendefinierade inställningar som är globala för hela applikationen. Se Java:s dokumentation av Properties för formateringsinformation.
+entity.ServerNode.property.workingGeneralSettings.label=Kompletterande egendefinierade inställningar som enbart gäller i arbetsläge (deliverWorking). Skriver över inställningar med samma nyckel från den allmänna listan.

--- a/src/java/org/infoglue/cms/applications/managementtool/actions/ViewServerNodePropertiesAction.java
+++ b/src/java/org/infoglue/cms/applications/managementtool/actions/ViewServerNodePropertiesAction.java
@@ -150,6 +150,8 @@ public class ViewServerNodePropertiesAction extends InfoGluePropertiesAbstractAc
 	    populate(ps, "pageKey");
 	    populate(ps, "componentKey");
 	    populateData(ps, "cacheSettings");
+	    populateData(ps, "generalSettings");
+	    populateData(ps, "workingGeneralSettings");
 	    populateData(ps, "extraPublicationPersistentCacheNames");
 	    populate(ps, "cmsBaseUrl");
 	    populate(ps, "cmsFullBaseUrl");

--- a/src/java/org/infoglue/deliver/controllers/kernel/impl/simple/BasicTemplateController.java
+++ b/src/java/org/infoglue/deliver/controllers/kernel/impl/simple/BasicTemplateController.java
@@ -44,6 +44,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 import java.util.Vector;
 
@@ -8729,4 +8730,27 @@ public class BasicTemplateController implements TemplateController
         return ( this instanceof EditOnSiteBasicTemplateController );
     }
 
+	public String getGeneralSetting(String key)
+	{
+		return getGeneralSetting(key, null);
+	}
+
+	public String getGeneralSetting(String key, String defaultValue)
+	{
+		Properties generalSettings = CmsPropertyHandler.getGeneralSettings(false);
+		String value = null;
+		if (generalSettings != null)
+		{
+			value = generalSettings.getProperty(key, defaultValue);
+		}
+		else
+		{
+			value = defaultValue;
+		}
+		if (logger.isDebugEnabled())
+		{
+			logger.debug("Returning value <" + value + "> for general setting key <" + key + ">");
+		}
+		return value;
+	}
 }

--- a/src/java/org/infoglue/deliver/controllers/kernel/impl/simple/TemplateController.java
+++ b/src/java/org/infoglue/deliver/controllers/kernel/impl/simple/TemplateController.java
@@ -51,6 +51,7 @@ import org.infoglue.cms.exception.SystemException;
 import org.infoglue.cms.security.InfoGlueGroup;
 import org.infoglue.cms.security.InfoGluePrincipal;
 import org.infoglue.cms.security.InfoGlueRole;
+import org.infoglue.cms.util.CmsPropertyHandler;
 import org.infoglue.cms.util.DesEncryptionHelper;
 import org.infoglue.cms.util.DocumentConverterHelper;
 import org.infoglue.deliver.applications.databeans.DatabaseWrapper;
@@ -1788,5 +1789,24 @@ public interface TemplateController
      * @return true if the pagenode is rendered with EditOnSight decoration.
      */
     public boolean getIsDecorated();
+
+	/**
+	 * Gets the value for the given <em>key</em> from the general settings. If the key is not
+	 * present in the settings null is returned.
+	 * @param key A key that should match a property in the general settings.
+	 * @return The value corresponding to the given key, or null of the key is not present.
+	 * @see CmsPropertyHandler#getGeneralSettings(boolean)
+	 */
+	public String getGeneralSetting(String key);
+
+	/**
+	 * Gets the value for the given <em>key</em> from the general settings. If the key is not
+	 * present in the settings <em>defaultValue</em> is returned.
+	 * @param key A key that should match a property in the general settings.
+	 * @param defaultValue If no value is found for the given key this value is returned.
+	 * @return The value corresponding to the given key, or null of the key is not present.
+	 * @see CmsPropertyHandler#getGeneralSettings(boolean)
+	 */
+	public String getGeneralSetting(String key, String defaultValue);
 
 }

--- a/src/java/org/infoglue/deliver/taglib/management/GeneralSettingTag.java
+++ b/src/java/org/infoglue/deliver/taglib/management/GeneralSettingTag.java
@@ -1,0 +1,46 @@
+package org.infoglue.deliver.taglib.management;
+
+import javax.servlet.jsp.JspException;
+
+import org.apache.log4j.Logger;
+import org.infoglue.deliver.controllers.kernel.impl.simple.TemplateController;
+import org.infoglue.deliver.taglib.TemplateControllerTag;
+
+/**
+ * Tag that provides an interface to the general settings feature.
+ * @author Erik Stenbacka <stenbacka@gmail.com>
+ */
+public class GeneralSettingTag extends TemplateControllerTag
+{
+	private static final long serialVersionUID = 774587456364945754L;
+	private static final Logger logger = Logger.getLogger(GeneralSettingTag.class);
+
+	private String key;
+	private String defaultValue;
+
+	@Override
+	public int doEndTag() throws JspException
+	{
+		TemplateController tc = getController();
+		if (logger.isInfoEnabled())
+		{
+			logger.info("Getting value for key <" + key + ">. SiteNode.id: " + tc.getSiteNodeId() + ". Component.id: " + tc.getComponentContentId());
+		}
+
+		produceResult(tc.getGeneralSetting(key, defaultValue));
+
+		this.key = null;
+		this.defaultValue = null;
+		return EVAL_PAGE;
+	}
+
+	public void setKey(String key) throws JspException
+	{
+		this.key = evaluateString("GeneralSettingTag", "key", key);
+	}
+
+	public void setDefault(String defaultValue) throws JspException
+	{
+		this.defaultValue = evaluateString("GeneralSettingTag", "defaultValue", defaultValue);
+	}
+}

--- a/src/webapp/cms/managementtool/viewServerNodeProperties.vm
+++ b/src/webapp/cms/managementtool/viewServerNodeProperties.vm
@@ -183,6 +183,8 @@
 				#yesNoDropDownWithInheritCSS("ServerNode.property.duplicateAssetsBetweenVersions" "duplicateAssetsBetweenVersions" "$this.getPropertyValue('duplicateAssetsBetweenVersions')" $!cmsPH.duplicateAssetsBetweenVersions)
 				#editPropertyTextAreaCSS("ServerNode.property.assetUploadTransformationsSettings" "assetUploadTransformationsSettings" "$this.getDataPropertyValue('assetUploadTransformationsSettings')" "40" "6" "righttextarea" "$!serverNodeId" $!cmsPH.assetUploadTransformationsSettings)
 				#yesNoDropDownWithInheritCSS("ServerNode.property.onlyShowReferenceIfLatestVersion" "onlyShowReferenceIfLatestVersion" "$this.getPropertyValue('onlyShowReferenceIfLatestVersion')" $!cmsPH.onlyShowReferenceIfLatestVersion)
+				#editPropertyTextAreaCSS("ServerNode.property.generalSettings" "generalSettings" "$this.getDataPropertyValue('generalSettings')" "40" "6" "righttextarea" "$!serverNodeId" $!cmsPH.generalSettings)
+				#editPropertyTextAreaCSS("ServerNode.property.workingGeneralSettings" "workingGeneralSettings" "$this.getDataPropertyValue('workingGeneralSettings')" "40" "6" "righttextarea" "$!serverNodeId" $!cmsPH.workingGeneralSettings)
 			</div>
 		
 			<div class="inlineTabDiv" id="niceURISettings">


### PR DESCRIPTION
The general settings is a way for the CMS users to specify application
wide settings. The settings can be read through the TemplateController
or using the the new tag management:generalSetting.

The values in the new property-set is defined using two fields. The first
is the primary field and is used like any other Properties-textarea combo.
The second field however is only used when in working-mode and overrides
settings in the first field if they share keys. This enables the user to
disable or change features when in working-mode.
