### PR TITLE
Improves logging view and log modification

### DIFF
--- a/conf/log4j.xml
+++ b/conf/log4j.xml
@@ -3,6 +3,10 @@
 
 <log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/" debug="false">
 
+	<!--
+	By default error level messages are logged here.
+	On a normal Tomcat installation events logged to the console will be piped
+	to catalina.out. -->
 	<appender name="CONSOLE" class="org.apache.log4j.ConsoleAppender">
 		<param name="Target" value="System.out"/>
 		<param name="Threshold" value="ERROR"/>
@@ -11,29 +15,48 @@
 		</layout>
 	</appender>
 
-	<appender name="CONSOLE-DEBUG" class="org.apache.log4j.ConsoleAppender">
-		<param name="Target" value="System.out"/>
-		<param name="Threshold" value="DEBUG"/>
-		<layout class="org.apache.log4j.PatternLayout">
-			<param name="ConversionPattern" value="%d{dd MMM yyyy HH:mm:ss.SSS} [%-5p] [%t] [%c] - %m%n"/>
-		</layout>
-	</appender>
-
+	<!--
+	Used to log warning level messages from Infoglue.
+	OBS: This has to be a subclass of the FileAppender class since Infoglue
+	  will set the file path to the log file dynamically. Also the name of the appender
+	  have to be 'INFOGLUE-FILE' and nothing else. -->
 	<appender name="INFOGLUE-FILE" class="org.apache.log4j.RollingFileAppender">
-		<!--<param name="File" value="${catalina.base}/logs/infoglue.log"/>-->
 		<param name="Append" value="true"/>
- 		<param name="MaxFileSize" value="10MB"/>
+		<param name="MaxFileSize" value="10MB"/>
 		<param name="MaxBackupIndex" value="5"/>
 		<param name="Threshold" value="WARNING"/>
 		<layout class="org.apache.log4j.PatternLayout">
 			<param name="ConversionPattern" value="%d{dd MMM yyyy HH:mm:ss.SSS} [%-5p] [%t] [%c] - %m%n"/>
 		</layout>
 		<filter class="org.apache.log4j.varia.LevelRangeFilter">
-      		<param name="LevelMin" value="WARN" />
-      		<param name="LevelMax" value="WARN" />
-    	</filter>
-   	</appender>
+			<param name="LevelMin" value="WARN" />
+			<param name="LevelMax" value="WARN" />
+		</filter>
+	</appender>
 
+	<!--
+	This appender is used to log events from categories whose level has been changed using
+	Infoglue's debug logging feature. See the Infoglue documentation for more information about this.
+	The appender type may be changed but the name has to be 'INFOGLUE-DEBUG' for the debug logging
+	feature to work. -->
+	<appender name="INFOGLUE-DEBUG" class="org.apache.log4j.ConsoleAppender">
+		<param name="Target" value="System.out"/>
+		<param name="Threshold" value="TRACE"/>
+		<layout class="org.apache.log4j.PatternLayout">
+			<param name="ConversionPattern" value="%d{dd MMM yyyy HH:mm:ss.SSS} [%-5p] [%t] [%c] - %m%n"/>
+		</layout>
+	</appender>
+
+	<!-- Not used anymore. Included for compatibility. -->
+	<appender name="CONSOLE-DEBUG" class="org.apache.log4j.ConsoleAppender">
+		<param name="Target" value="System.out"/>
+		<param name="Threshold" value="TRACE"/>
+		<layout class="org.apache.log4j.PatternLayout">
+			<param name="ConversionPattern" value="%d{dd MMM yyyy HH:mm:ss.SSS} [%-5p] [%t] [%c] - %m%n"/>
+		</layout>
+	</appender>
+
+	<!-- Not used anymore. Included for compatibility. -->
 	<appender name="INFOGLUE-FILE-DEBUG" class="org.apache.log4j.RollingFileAppender">
 		<param name="File" value="${catalina.base}/logs/infoglue-debug.log"/>
 		<param name="Append" value="true"/>
@@ -44,11 +67,11 @@
 			<param name="ConversionPattern" value="%d{dd MMM yyyy HH:mm:ss.SSS} [%-5p] [%t] [%c] - %m%n"/>
 		</layout>
 		<filter class="org.apache.log4j.varia.LevelRangeFilter">
-      		<param name="LevelMin" value="DEBUG" />
-      		<param name="LevelMax" value="INFO" />
-    	</filter>
-   	</appender>
- 
+			<param name="LevelMin" value="DEBUG" />
+			<param name="LevelMax" value="INFO" />
+		</filter>
+	</appender>
+
 	<!-- Appender Chainsaw GUI Log viewer
 	<appender name="CHAINSAW" class="org.apache.log4j.net.SocketAppender">
 		<param name="remoteHost" value="localhost"/>
@@ -148,6 +171,15 @@
 	
 	<category name="net.sf.hibernate">
 		<priority value="WARN"/>
+	</category>
+
+	<!--
+	This category is used by Infoglue to access the INFOGLUE-DEBUG appender
+	If this category is changed or removed Infoglue's debug loggin feature
+	may stop working. -->
+	<category name="org.infoglue.debug-dummy">
+		<priority value="ERROR"/>
+		<appender-ref ref="INFOGLUE-DEBUG"/>
 	</category>
 
 	<!-- Anyhing not caught by the above categories will be caught here -->

--- a/src/java/org/infoglue/cms/applications/managementtool/actions/ViewLoggingAction.java
+++ b/src/java/org/infoglue/cms/applications/managementtool/actions/ViewLoggingAction.java
@@ -57,10 +57,10 @@ public class ViewLoggingAction extends InfoGlueAbstractAction
     private final static Logger logger = Logger.getLogger(ViewLoggingAction.class.getName());
 
 	private static final long serialVersionUID = 1L;
-	
+
 	private String logFragment = "";
 	private int logLines = 50;
-	private List logFiles = new ArrayList();
+	private List<File> logFiles = new ArrayList<File>();
 	private String logFileName = null;
 
 	/**
@@ -69,20 +69,16 @@ public class ViewLoggingAction extends InfoGlueAbstractAction
 	 */
 	public String doDownloadFile() throws Exception
 	{
-		boolean allowAccess = true;
         if(!ServerNodeController.getController().getIsIPAllowed(getRequest()))
         {
         	java.security.Principal principal = (java.security.Principal)getHttpSession().getAttribute("infogluePrincipal");
     		if(principal == null)
     			principal = getInfoGluePrincipal();
-    		
     		if(principal != null && org.infoglue.cms.controllers.kernel.impl.simple.AccessRightController.getController().getIsPrincipalAuthorized((org.infoglue.cms.security.InfoGluePrincipal)principal, "ViewApplicationState.Read", false, true))
     		{
-    			allowAccess = true;
     		}
     		else
     		{
-    			allowAccess = false;
     			logger.error("A client with IP " + getRequest().getRemoteAddr() + " was denied access to the download action. Could be a hack attempt or you have just not configured the allowed IP-addresses correct.");
                	this.getResponse().setContentType("text/plain");
                 this.getResponse().setStatus(HttpServletResponse.SC_FORBIDDEN);
@@ -90,24 +86,24 @@ public class ViewLoggingAction extends InfoGlueAbstractAction
                 return NONE;
     		}
         }
-    	
+
     	if(logFileName != null && !logFileName.equals(""))
     	{
         	String catalinaBase = System.getProperty("catalina.base");
         	if(catalinaBase == null || catalinaBase.equals(""))
-        	{	
+        	{
         		catalinaBase = CmsPropertyHandler.getContextRootPath().substring(0, CmsPropertyHandler.getContextRootPath().lastIndexOf("/"));
         	}
         	catalinaBase = catalinaBase + File.separator + "logs";
 
         	String velocityLog = CmsPropertyHandler.getContextRootPath() + File.separator + "velocity.log";
 
-    		List fileList = Arrays.asList(new File(catalinaBase).listFiles());
+    		List<File> fileList = Arrays.asList(new File(catalinaBase).listFiles());
     		logFiles.addAll(fileList);
-    		
-    		List debugFileList = Arrays.asList(new File(CmsPropertyHandler.getContextRootPath() + File.separator + "logs").listFiles());
+
+    		List<File> debugFileList = Arrays.asList(new File(CmsPropertyHandler.getContextRootPath() + File.separator + "logs").listFiles());
     		logFiles.addAll(debugFileList);
-    		
+
     		File velocityLogFile = new File(velocityLog);
     		if(velocityLogFile.exists())
     		{
@@ -123,10 +119,10 @@ public class ViewLoggingAction extends InfoGlueAbstractAction
 	    		HttpServletResponse response = this.getResponse();
 	    		response.addHeader("Content-Type", "application/force-download");
 	    		response.addHeader("Content-Disposition", "attachment; filename=\"downloadedLog.txt\"");
-	    		
+
 		        // print some html
 		        ServletOutputStream out = response.getOutputStream();
-		        
+
 		        // print the file
 		        InputStream in = null;
 		        try 
@@ -151,51 +147,48 @@ public class ViewLoggingAction extends InfoGlueAbstractAction
                 return NONE; 
     		}
     	}
-    	
+
 		return NONE;
 	}
-	
+
 	/**
 	 * This is the normal log view action. Takes a file name as input and tail the file with x-lines.
 	 */
     public String doExecute() throws Exception
     {
-    	boolean allowAccess = true;
     	if(!ServerNodeController.getController().getIsIPAllowed(this.getRequest()))
         {
     		java.security.Principal principal = (java.security.Principal)getHttpSession().getAttribute("infogluePrincipal");
     		if(principal == null)
     			principal = getInfoGluePrincipal();
-    		
+
     		if(principal != null && org.infoglue.cms.controllers.kernel.impl.simple.AccessRightController.getController().getIsPrincipalAuthorized((org.infoglue.cms.security.InfoGluePrincipal)principal, "ViewApplicationState.Read", false, true))
     		{
-    			allowAccess = true;
     		}
     		else
     		{
-    			allowAccess = false;
     			this.getResponse().setContentType("text/plain");
                 this.getResponse().setStatus(HttpServletResponse.SC_FORBIDDEN);
                 this.getResponse().getWriter().println("You have no access to this view - talk to your administrator if you should. Try go through the ViewApplicationState.action if you have an account that have access.");
                 return NONE;
     		}
         }
-    	
+
     	String catalinaBase = System.getProperty("catalina.base");
     	if(catalinaBase == null || catalinaBase.equals(""))
-    	{	
+    	{
     		catalinaBase = CmsPropertyHandler.getContextRootPath().substring(0, CmsPropertyHandler.getContextRootPath().lastIndexOf("/"));
     	}
     	catalinaBase = catalinaBase + File.separator + "logs";
 
     	String velocityLog = CmsPropertyHandler.getContextRootPath() + File.separator + "velocity.log";
 
-		List fileList = Arrays.asList(new File(catalinaBase).listFiles());
+		List<File> fileList = Arrays.asList(new File(catalinaBase).listFiles());
 		logFiles.addAll(fileList);
-		
-		List debugFileList = Arrays.asList(new File(CmsPropertyHandler.getContextRootPath() + File.separator + "logs").listFiles());
+
+		List<File> debugFileList = Arrays.asList(new File(CmsPropertyHandler.getContextRootPath() + File.separator + "logs").listFiles());
 		logFiles.addAll(debugFileList);
-		
+
 		File velocityLogFile = new File(velocityLog);
 		if(velocityLogFile.exists())
 		{
@@ -211,10 +204,10 @@ public class ViewLoggingAction extends InfoGlueAbstractAction
 			if(logFiles.size() > 0)
 			{
 				fileName = ((File)logFiles.get(0)).getPath();
-				Iterator filesIterator = logFiles.iterator();
+				Iterator<File> filesIterator = logFiles.iterator();
 				while(filesIterator.hasNext())
 				{
-					File file = (File)filesIterator.next();
+					File file = filesIterator.next();
 					if(file.getName().equals("catalina.out"))
 					{
 						fileName = file.getPath();
@@ -222,26 +215,27 @@ public class ViewLoggingAction extends InfoGlueAbstractAction
 					}
 				}
 			}
+			logFileName = fileName;
 		}
 		else
 		{
 			fileName = "An invalid file requested - could be an hack attempt:" + logFileName;
-			Iterator filesIterator = logFiles.iterator();
+			Iterator<File> filesIterator = logFiles.iterator();
 			while(filesIterator.hasNext())
 			{
-				File file = (File)filesIterator.next();
+				File file = filesIterator.next();
 				if(file.getPath().equals(logFileName))
 				{
 					fileName = logFileName;
 					break;
 				}
-			}			
+			}
 		}
-					
+
 		File file = new File(fileName);
-		
+
     	logFragment = FileHelper.tail(file, logLines);
-    	
+
         return "success";
     }
 
@@ -250,7 +244,7 @@ public class ViewLoggingAction extends InfoGlueAbstractAction
 		return logFragment;
 	}
 
-	public List getLogFiles() 
+	public List<File> getLogFiles() 
 	{
 		return logFiles;
 	}
@@ -274,19 +268,19 @@ public class ViewLoggingAction extends InfoGlueAbstractAction
 	{
 		this.logFileName = logFileName;
 	}
-    
+
 	public String getLastModifiedDateString(long lastModified)
 	{
 		Date date = new Date(lastModified);
 		String lastModifiedDateString = new VisualFormatter().formatDate(date, "yy-MM-dd HH:ss");
-		
+
 		return lastModifiedDateString;
 	}
 
 	public String getFileSize(long size)
 	{
 		String fileSize = new MathHelper().fileSize(size);
-		
+
 		return fileSize;
 	}
 }

--- a/src/java/org/infoglue/cms/util/sorters/FileComparator.java
+++ b/src/java/org/infoglue/cms/util/sorters/FileComparator.java
@@ -11,7 +11,7 @@ import org.apache.log4j.Logger;
  * @author Mattias Bogeblad
  */
 
-public class FileComparator implements Comparator
+public class FileComparator implements Comparator<Object>
 {
     private final static Logger logger = Logger.getLogger(FileComparator.class.getName());
 

--- a/src/java/org/infoglue/deliver/controllers/kernel/impl/simple/LogModifierController.java
+++ b/src/java/org/infoglue/deliver/controllers/kernel/impl/simple/LogModifierController.java
@@ -1,0 +1,186 @@
+package org.infoglue.deliver.controllers.kernel.impl.simple;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
+import org.apache.log4j.Appender;
+import org.apache.log4j.ConsoleAppender;
+import org.apache.log4j.Layout;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.apache.log4j.PatternLayout;
+import org.infoglue.cms.controllers.kernel.impl.simple.BaseController;
+import org.infoglue.cms.entities.kernel.BaseEntityVO;
+
+public class LogModifierController extends BaseController
+{
+	private static final Logger classLogger = Logger.getLogger(LogModifierController.class);
+	private static LogModifierController controller;
+
+	private Map<Logger, ModificationInformation> currentModifications;
+	private Appender debugAppender;
+	private Map<Integer, Level> levels;
+
+	private static synchronized void initController()
+	{
+		if (controller == null)
+		{
+			controller = new LogModifierController();
+		}
+	}
+
+	public static LogModifierController getController()
+	{
+		if (controller == null)
+		{
+			initController();
+		}
+		return controller;
+	}
+
+	private LogModifierController()
+	{
+		this.currentModifications = new HashMap<Logger, ModificationInformation>();
+		initDebugAppender();
+	}
+
+	private void initDebugAppender()
+	{
+		if (debugAppender == null)
+		{
+			debugAppender = Logger.getLogger("org.infoglue.debug-dummy").getAppender("INFOGLUE-DEBUG");
+			if (debugAppender == null)
+			{
+				classLogger.warn("Did not find a debug appender. There should be an appender named INFOGLUE-DEBUG and it should be referenced by a category named org.infoglue.debug-dummy. Will use a Console appender instead.");
+				Layout layout = new PatternLayout("%d{dd MMM yyyy HH:mm:ss.SSS} [Debug log] [%-5p] [%t] [%c] - %m%n");
+				ConsoleAppender appender = new ConsoleAppender(layout);
+				appender.setThreshold(Level.TRACE);
+				debugAppender = appender;
+			}
+		}
+	}
+
+	private void populateLevels()
+	{
+		classLogger.debug("Populating levels");
+		levels = new TreeMap<Integer, Level>();
+		levels.put(Level.TRACE.toInt(), Level.TRACE);
+		levels.put(Level.DEBUG.toInt(), Level.DEBUG);
+		levels.put(Level.INFO.toInt(), Level.INFO);
+		levels.put(Level.WARN.toInt(), Level.WARN);
+		levels.put(Level.ERROR.toInt(), Level.ERROR);
+		levels.put(Level.FATAL.toInt(), Level.FATAL);
+		levels.put(Level.OFF.toInt(), Level.OFF);
+	}
+
+	public Map<Integer, Level> getLevels()
+	{
+		if (levels == null)
+    	{
+    		populateLevels();
+    	}
+		return levels;
+	}
+
+	public void changeLogLevel(String loggerName, Integer loggerLevel)
+	{
+		Logger logger = Logger.getLogger(loggerName);
+		Level level = loggerLevel == null ? null : Level.toLevel(loggerLevel);
+		changeLogLevel(logger, level);
+	}
+
+	public void changeLogLevel(String loggerName, Level level)
+	{
+		Logger logger = Logger.getLogger(loggerName);
+		changeLogLevel(logger, level);
+	}
+
+	public void changeLogLevel(Logger logger, Integer loggerLevel)
+	{
+		Level level = loggerLevel == null ? null : Level.toLevel(loggerLevel);
+		changeLogLevel(logger, level);
+	}
+
+	public synchronized void changeLogLevel(Logger logger, Level level)
+	{
+		if (logger == null)
+		{
+			classLogger.warn("Tried to change logging level without the required information. Logger: " + logger + ". Level " + level);
+		}
+		else
+		{
+			if (level == null)
+			{
+				clearModifications(logger);
+			}
+			else
+			{
+				ModificationInformation currentState = currentModifications.get(logger);
+				if (currentState == null)
+				{
+					classLogger.info("Logger has not been modified. Logger: " + logger.getName() + ". New level: " + level);
+					currentState = new ModificationInformation();
+					currentState.originalLevel = logger.getLevel();
+					currentState.currentLevel = level;
+					logger.setLevel(level);
+					currentModifications.put(logger, currentState);
+
+					logger.addAppender(debugAppender);
+				}
+				else
+				{
+					classLogger.info("Logger has been modified. Logger: " + logger.getName() + ". New level: " + level);
+					currentState.currentLevel = level;
+					logger.setLevel(level);
+				}
+			}
+		}
+	}
+
+	public void clearModifications(String loggerName)
+	{
+		clearModifications(Logger.getLogger(loggerName));
+	}
+
+	public synchronized void clearModifications(Logger logger)
+	{
+		ModificationInformation currentState = currentModifications.get(logger);
+		if (currentState == null)
+		{
+			classLogger.info("No modifications to clear in logger. Logger: " + logger.getName());
+		}
+		else
+		{
+			classLogger.debug("Clearing modifications for Logger. Logger: " + logger.getName() + ". Modificatons: " + currentState);
+			logger.setLevel(currentState.originalLevel);
+			logger.removeAppender(debugAppender);
+			currentModifications.remove(logger);
+		}
+	}
+
+	public Set<Logger> getCurrentModifications()
+	{
+		return currentModifications.keySet();
+	}
+
+	@Override
+	public BaseEntityVO getNewVO()
+	{
+		return null;
+	}
+
+	private static class ModificationInformation
+	{
+		Level currentLevel;
+		Level originalLevel;
+
+		@Override
+		public String toString()
+		{
+			return "[currentLevel: " + currentLevel + ", originalLevel: " + originalLevel + "]";
+		}
+	}
+
+}

--- a/src/webapp/cms/managementtool/viewLogging.vm
+++ b/src/webapp/cms/managementtool/viewLogging.vm
@@ -8,39 +8,69 @@
 		}
 	-->
 	</script>
+
+	<style type="text/css">
+		html, body, .fullymarginalized {height: 100%;}
+		#logControllers {
+			display: block;
+			width: 100%;
+			height: 160px;
+			padding: 20px;
+			box-sizing: border-box;
+		}
+		#logViewContainer {
+			width:100%;
+			height: 360px;
+			height: -moz-calc(100% - 160px);
+			height: -webkit-calc(100% - 160px);
+			height: calc(100% - 160px);
+			box-sizing:border-box;
+			padding: 20px;
+			padding-top: 0;
+		}
+		#logViewContainer > textarea {
+			width: 100%;
+			height: 100%;
+			font-family: Arial;
+			font-size: 10px;
+			border: 1px solid #333333;
+			box-sizing: border-box;
+		}
+	</style>
 #end
 
 #beginLightCommonToolV3Impl("tool.managementtool.viewSystemTools.header" "" "" false true false $headerMarkup false "")
 
 <div class="fullymarginalized">
 
+	<header id="logControllers">
 	<h3>$ui.getString("tool.managementtool.loggingTool.header")</h3>
-	<form id="logForm" name="logForm" action="ViewLogging.action"> 
-		<strong>$ui.getString("tool.managementtool.logFiles.label"):</strong><br/>
-		<select id="logFileName" name="logFileName">
-			#foreach($file in $logFiles)
-			#set($fileSize = $this.getFileSize($file.length()))
-			<option value="$file.path" #checkSelected("$file.path" $!logFileName)>$file.name ($this.getLastModifiedDateString($file.lastModified()) - Size: $fileSize)</option>
-			#end
-		</select>
-		<strong>$ui.getString("tool.managementtool.logLines.label"):</strong>
-		<select id="logLines" name="logLines">
-			<option value="10" #checkSelected("$logLines" "10")>10</option>
-			<option value="50" #checkSelected("$logLines" "50")>50</option>
-			<option value="100" #checkSelected("$logLines" "100")>100</option>
-			<option value="500" #checkSelected("$logLines" "500")>500</option>
-			<option value="1000" #checkSelected("$logLines" "1000")>1000</option>
-			<option value="10000" #checkSelected("$logLines" "10000")>10000</option>
-		</select>
-		<a href="#" onclick="downloadFile(); return false;">$ui.getString("tool.common.download.label")</a>
-		<br/>
-		
-		<strong>$ui.getString("tool.managementtool.logFragment.label"):</strong><br/>
-  	</form>
-  	<p>
-  		<textarea id="logFragment" name="logFragment" class="normaltextfield" rows="10" cols="50" style="width:90%; height: 400px; border: 1px solid #333333; font-family: Arial; font-size: 10px;">$logFragment</textarea><br/>
-		<input id="submit" type="submit" value="$ui.getString("tool.managementtool.logRefresh.label")" onclick="document.logForm.submit();"/>
-	</p>
+		<form id="logForm" name="logForm" action="ViewLogging.action">
+			<strong>$ui.getString("tool.managementtool.logFiles.label"):</strong><br/>
+			<select id="logFileName" name="logFileName">
+				#foreach($file in $logFiles)
+				#set($fileSize = $this.getFileSize($file.length()))
+				<option value="$file.path" #if("$file.path" == "$!logFileName") selected="selected" #end>$file.name ($this.getLastModifiedDateString($file.lastModified()) - Size: $fileSize)</option>
+				#end
+			</select>
+			<strong>$ui.getString("tool.managementtool.logLines.label"):</strong>
+			<select id="logLines" name="logLines">
+				<option value="10" #if("$logLines" == "10") selected="selected" #end>10</option>
+				<option value="50" #if("$logLines" == "50") selected="selected" #end>50</option>
+				<option value="100" #if("$logLines" == "100") selected="selected" #end>100</option>
+				<option value="500" #if("$logLines" == "500") selected="selected" #end>500</option>
+				<option value="1000" #if("$logLines" == "1000") selected="selected" #end>1000</option>
+				<option value="10000" #if("$logLines" == "10000") selected="selected" #end>10000</option>
+			</select>
+			<input id="submit" type="submit" value="$ui.getString("tool.managementtool.logRefresh.label")" onclick="document.logForm.submit();"/>
+			<a href="#" onclick="downloadFile(); return false;">$ui.getString("tool.common.download.label")</a>
+			<br/><br/>
+			<strong>$ui.getString("tool.managementtool.logFragment.label") ($!logFileName):</strong><br/>
+		</form>
+	</header>
+	<div id="logViewContainer">
+		<textarea id="logFragment" name="logFragment" class="normaltextfield" rows="10" cols="50">$logFragment</textarea><br/>
+	</div>
 </div>
 
 </body>

--- a/src/webapp/deliver/viewApplicationState.vm
+++ b/src/webapp/deliver/viewApplicationState.vm
@@ -57,7 +57,32 @@
 			margin-right: 50px;
 			margin-top	: 10%;
 		}
-		
+
+		ul.linkList {
+			list-style-type: none;
+			margin: 0;
+			padding: 0;
+		}
+
+		ul.linkList a:visited {
+			color: blue;
+		}
+
+		li.linkList {
+			margin: 0 0 0 10px;
+			padding: 0;
+			display: inline-block;
+		}
+
+		li.linkList::before {
+			content: "|";
+			margin-right: 10px;
+		}
+		li.linkList:first-child::before {
+			margin: 0;
+			content: "";
+		}
+
 	-->
 	</style>
 	<script type="text/javascript">
@@ -77,10 +102,10 @@
 				if(div && div.style.display == 'table-row')
 					div.style.display = 'none';
 				else
-					div.style.display = 'table-row';				
+					div.style.display = 'table-row';
 			}
 		}
-	-->		
+	-->
 	</script>
 </head>
 
@@ -146,20 +171,40 @@
   <tr class="label">
     <td colspan="4">Log settings</td>
   </tr>
+  #if($currentModifications.size() > 0)
+  <tr>
+    <td colspan="4" class="text" style="border-bottom: 1px solid #999999;" align="left">
+      <strong>Current log modifications</strong>
+    </td>
+  </tr>
+  #end
+  #foreach($modification in $currentModifications)
+  <tr>
+    <td style="border-bottom: 1px solid #999999;" class="text">
+      $modification.name
+    </td>
+    <td colspan="3" style="border-bottom: 1px solid #999999; text-transform:lowercase;" class="text">
+      #foreach($entry in $levels.entrySet())
+       <a href="ViewApplicationState!setLogLevel.action?className=$modification.name&logLevel=$entry.key" #if($modification.level == $entry.value) style="text-decoration: none; color:black;" onclick="return false;" #end>$entry.value</a> |
+	  #end
+	  <a href="ViewApplicationState!setLogLevel.action?className=$modification.name"><strong>clear</strong></a>
+    </td>
+  </tr>
+  #end
   <tr>
     <td colspan="4" class="text" align="left">
-    	<form action="ViewApplicationState!setLogLevel.action"> 
+    	<form action="ViewApplicationState!setLogLevel.action" id="logForm"> 
 	    	ClassName:
-	    	<input type="textfield" name="className">
+	    	<input type="textfield" name="className" id="classNameField">
 	    	Log level:
 	    	<select name="logLevel">
-	    		<option value="debug">Debug</option>
-	    		<option value="info">Information</option>
-	    		<option value="warn">Warning</option>
-	    		<option value="error">Error</option>
+	    		#foreach($entry in $levels.entrySet())
+	    			<option value="$entry.key">$entry.value</option>
+	    		#end
 	    	</select>
 	    	<input type="submit" value="Submit"/>
 	    </form>
+	    
     </td>
   </tr>
   <tr>


### PR DESCRIPTION
== Log view
Fixes a problem where the selected file and line count was not selected
on submit. Moves the refresh button closer to the other controller
elements. Makes the log view larger by default.

== Log modification
Adds some documentation to the log4.xml file that explaines the use cases
for the available appenders. Also adds a new "template" appender that is
used by the new log modification logic. If the template appender is not
present a Console appender will be used instead.

Adds possibility to set the logger's level to Trace, Fatal, and Off.

When a logger's level is changed the modification is now remebered by the
system. This enables a couple of features. (1) the active modifications
are displayed on the Application state view, (2) easier to revert the
modification through a UI element in the application state view, and (3)
the system can properly restore the logger to its original state.
