### PR TITLE
Hides unrelated tabs from the metadata view

### DIFF
--- a/src/java/org/infoglue/cms/applications/contenttool/actions/ViewContentVersionAction.java
+++ b/src/java/org/infoglue/cms/applications/contenttool/actions/ViewContentVersionAction.java
@@ -162,7 +162,9 @@ public class ViewContentVersionAction extends InfoGlueAbstractAction
 	//Set to true if version was a state change
 	private Boolean stateChanged = false;
 	private Boolean considerLatest = false;
-	
+
+	private boolean isMetainfoContent = false;
+
 	public String getQualifyerPath(String entity, String entityId)
 	{	
 		StringBuffer sb = new StringBuffer("");
@@ -375,12 +377,20 @@ public class ViewContentVersionAction extends InfoGlueAbstractAction
 		}
 		*/
 
-        if(this.contentTypeDefinitionVO != null)
-        {
-            this.contentTypeDefinitionVO = ContentTypeDefinitionController.getController().validateAndUpdateContentType(this.contentTypeDefinitionVO);
-            this.attributes = ContentTypeDefinitionController.getController().getContentTypeAttributes(this.contentTypeDefinitionVO, true);
-            this.tabbedAttributes = ContentTypeDefinitionController.getController().getTabbedContentTypeAttributes(this.contentTypeDefinitionVO, true);
-        }
+		if(this.contentTypeDefinitionVO != null)
+		{
+			this.contentTypeDefinitionVO = ContentTypeDefinitionController.getController().validateAndUpdateContentType(this.contentTypeDefinitionVO);
+			this.attributes = ContentTypeDefinitionController.getController().getContentTypeAttributes(this.contentTypeDefinitionVO, true);
+			this.tabbedAttributes = ContentTypeDefinitionController.getController().getTabbedContentTypeAttributes(this.contentTypeDefinitionVO, true);
+			if (this.contentTypeDefinitionVO.getName().equals(CmsPropertyHandler.getMetaDataContentTypeDefinitionName()))
+			{
+				if (logger.isDebugEnabled())
+				{
+					logger.debug("This content is a meta info! Content.id: " + contentId + ". The content type is: <" + contentTypeDefinitionVO.getName() + "> and the system metadata content type is <" + CmsPropertyHandler.getMetaDataContentTypeDefinitionName() + ">");
+				}
+				this.isMetainfoContent = true;
+			}
+		}
 
         if(this.fromLanguageId != null)
 			this.originalLanguageContentVersionVO = ContentVersionController.getContentVersionController().getLatestActiveContentVersionVO(contentId, fromLanguageId);
@@ -2103,6 +2113,35 @@ public class ViewContentVersionAction extends InfoGlueAbstractAction
 	public void setConsiderLatest(Boolean considerLatest) 
 	{
 		this.considerLatest = considerLatest;
+	}
+
+	public boolean getIsMetainfoContent()
+	{
+		return isMetainfoContent;
+	}
+
+	public String getCategoriesInterceptionPoint()
+	{
+		if (isMetainfoContent)
+		{
+			return "SiteNodeVersionEditor.Categories";
+		}
+		else
+		{
+			return "ContentVersionEditor.Categories";
+		}
+	}
+
+	public String getAttachmentsInterceptionPoint()
+	{
+		if (isMetainfoContent)
+		{
+			return "SiteNodeVersionEditor.Attachments";
+		}
+		else
+		{
+			return "ContentVersionEditor.Attachments";
+		}
 	}
 
 }

--- a/src/java/org/infoglue/cms/controllers/kernel/impl/simple/InterceptionPointController.java
+++ b/src/java/org/infoglue/cms/controllers/kernel/impl/simple/InterceptionPointController.java
@@ -117,7 +117,9 @@ public class InterceptionPointController extends BaseController
 	    systemInterceptionPoints.put("SiteNodeVersion.ChangeAccessRights", new InterceptionPointVO("SiteNodeVersion", "SiteNodeVersion.ChangeAccessRights", "Intercepts the attempt to change access rights", true));
 	    systemInterceptionPoints.put("SiteNodeVersion.Publish", new InterceptionPointVO("SiteNodeVersion", "SiteNodeVersion.Publish", "Intercepts the direct publishing of a siteNode version", true));
 	    systemInterceptionPoints.put("SiteNode.ExpireDateComingUp", new InterceptionPointVO("SiteNode", "SiteNode.ExpireDateComingUp", "Intercepts the event of a site node coming close to it's expire date", true));
-	    
+		systemInterceptionPoints.put("SiteNodeVersionEditor.Categories", new InterceptionPointVO("SiteNodeVersionEditor", "SiteNodeVersionEditor.Categories", "Intercepts the the categories on SiteNodes", false));
+		systemInterceptionPoints.put("SiteNodeVersionEditor.Attachments", new InterceptionPointVO("SiteNodeVersionEditor", "SiteNodeVersionEditor.Attachments", "Intercepts the the attachments on SiteNodes", false));
+
 	    systemInterceptionPoints.put("StructureTool.PageTemplateIsOptional", new InterceptionPointVO("StructureTool", "StructureTool.PageTemplateIsOptional", "This interception point limits who has to supply a page template when creating a page", false));
 	    systemInterceptionPoints.put("StructureTool.Palette", new InterceptionPointVO("StructureTool", "StructureTool.Palette", "This interception point limits who sees the toolbar", false));
 	    

--- a/src/java/org/infoglue/cms/util/CmsPropertyHandler.java
+++ b/src/java/org/infoglue/cms/util/CmsPropertyHandler.java
@@ -2961,4 +2961,15 @@ public class CmsPropertyHandler
 
 		return Boolean.parseBoolean(redirectUsingSystemRedirect);
 	}
+
+	/**
+	 * Dev note: This method is not used at all places where it should be used so don't depend on that. However
+	 * it is good if new features utilize this property so that in the future we can depend on this attribute.
+	 * (Comment written on 2014-01-24)
+	 */
+	public static String getMetaDataContentTypeDefinitionName()
+	{
+		return getServerNodeProperty("metaDataContentTypeDefinitionName", true, "Meta info");
+	}
+
 }

--- a/src/webapp/cms/contenttool/v3/viewContentVersionStandaloneForFCKEditor.vm
+++ b/src/webapp/cms/contenttool/v3/viewContentVersionStandaloneForFCKEditor.vm
@@ -454,7 +454,7 @@
 			{
 				loadFrame("contentVersionAssetsDiv");
 
-				#if($this.hasAccessTo("ContentVersionEditor.Categories", true, false))
+				#if($this.hasAccessTo($categoriesInterceptionPoint, true, false))
 					$("#tabsContainer").tabs("select", 2);
 				#else
 					$("#tabsContainer").tabs("select", 1);
@@ -513,27 +513,31 @@
 			$("input.attachAsset").hide();
 			
 			#if($anchor)
-		    	#if($!anchor == "contentVersionBlock")
-			    	$("#tabsContainer").tabs({ selected: 0, cache: false, show:function(event, ui) { resizeScrollArea(); }, select: function(e, ui) { loadFrame(ui.tab.href); }}  );
-			    #elseif($!anchor == "categoriesBlock")
-			    	$("#tabsContainer").tabs({ selected: 1, cache: false, show:function(event, ui) { resizeScrollArea(); }, select: function(e, ui) { loadFrame(ui.tab.href); }}  );
-			    #elseif($!anchor == "digitalAssetsBlock")
-			    	$("#tabsContainer").tabs({ selected: 2, cache: false, show:function(event, ui) { resizeScrollArea(); }, select: function(e, ui) { loadFrame(ui.tab.href); }}  );
-			    	loadFrame(2);
-			    #else 
-		  			$("#tabsContainer").tabs({ cache: false, show:function(event, ui) { resizeScrollArea(); }, select: function(e, ui) { loadFrame(ui.tab.href); }}  );
-			    	##alert("Anchor: $anchor");
-		  		#end
-		  	#else
-		  		$("#tabsContainer").tabs(
-		  			{ 
-		  				cache: false, 
-		  				show:function(event, ui) { resizeScrollArea(); },
-		  				select: function(e, ui) { loadFrame(ui.tab.href); }
-		  			} 
-		  		);
+				#if($!anchor == "contentVersionBlock")
+					$("#tabsContainer").tabs({ selected: 0, cache: false, show:function(event, ui) { resizeScrollArea(); }, select: function(e, ui) { loadFrame(ui.tab.href); }}  );
+				#elseif($!anchor == "categoriesBlock")
+					$("#tabsContainer").tabs({ selected: 1, cache: false, show:function(event, ui) { resizeScrollArea(); }, select: function(e, ui) { loadFrame(ui.tab.href); }}  );
+				#elseif($!anchor == "digitalAssetsBlock")
+					#set( $selectedIndex = 1 )
+					#if($this.hasAccessTo($categoriesInterceptionPoint, true, false))
+						#set( $selectedIndex = 2 )
+					#end
+					$("#tabsContainer").tabs({ selected: $selectedIndex, cache: false, show:function(event, ui) { resizeScrollArea(); }, select: function(e, ui) { loadFrame(ui.tab.href); }}  );
+					loadFrame("contentVersionAssetsDiv");
+				#else
+					$("#tabsContainer").tabs({ cache: false, show:function(event, ui) { resizeScrollArea(); }, select: function(e, ui) { loadFrame(ui.tab.href); }}  );
+					##alert("Anchor: $anchor");
+				#end
+			#else
+				$("#tabsContainer").tabs(
+					{
+						cache: false,
+						show:function(event, ui) { resizeScrollArea(); },
+						select: function(e, ui) { loadFrame(ui.tab.href); }
+					}
+				);
 			#end	
-			
+
 			#if($translate)
 			  	$("#otherLanguageTabsContainer").tabs({ cache: false, show:function() { resizeScrollArea(); }, select: function(e, ui) { loadFrame(ui.tab.href); }}  );
 			#end
@@ -542,45 +546,49 @@
 	
 			$("#contentTypeAttributesTable :input").change(function () {
 				if($(this).attr("id").indexOf("categoryId") == -1)
-				{		  
+				{
 					setDirty();
 				}
-		    });
-						
+			});
+
 			$("#editForm").submit(function () { return false; });	
 			
 			try
 			{
+				#if($isMetainfoContent == false)
 				jQuery.get("ViewCommonAjaxServices!referenceCount.action?contentId=$contentId", function(data) {
-					//alert("Count:" + data + " on $contentId");
 					if(data != "0")
 						$('a[href="#contentReferencesDiv"] > span').append("(" + data + ")");
 				});
+				#end
 
 				#if($contentVersionId)
-	
+
+					#if($this.hasAccessTo($attachmentsInterceptionPoint, true, false))
 					jQuery.get("ViewCommonAjaxServices!assetCount.action?contentVersionId=$contentVersionId", function(data) {
 						//alert("Count:" + data + " on $contentId");
 						if(data != "0")
 							$('a[href="#contentVersionAssetsDiv"] > span').append("(" + data + ")");
 					});
-	
+					#end
+
+					#if($this.hasAccessTo($categoriesInterceptionPoint, true, false))
 					jQuery.get("ViewCommonAjaxServices!categoryCount.action?contentVersionId=$contentVersionId", function(data) {
 						//alert("Count:" + data + " on $contentId");
 						if(data != "0")
 							$('a[href="#contentVersionCategoriesDiv"] > span').append("(" + data + ")");
-					});	
+					});
+					#end
 
 				#end
 			}
 			catch(e) {console.log("e:" + e);}	
-	  	});
-	  	
+		});
 
 	    /*
 	     * This method acts as a proxy to the frame that has the view in the tabbed world we live in.
 	 	 */	
-	    					 	
+
 	    function compare()
 	    {
 	    	if($("#contentHistoryFrame").get(0).contentWindow.compare)
@@ -637,7 +645,7 @@
 			
 			if(beenWarned)
 			{
-				answer = confirm("You have not saved for " + pastedTime + " minutes. We strongly recommends you copy the text so you don't risk loosing it if you have been inactive for to long. Do you want to save anyway?");
+				answer = confirm("You have not saved for " + pastedTime + " minutes. We strongly recommends you copy the text so you don't risk losing it if you have been inactive for to long. Do you want to save anyway?");
 			}
 			
 			if (!beenWarned || answer)
@@ -828,7 +836,7 @@
 ##end
 
 <div style="z-index: 3;">
-    
+
 	#lightMenuToolbar("" $buttons $rightButtons) 
 
 	<div style="clear: both;"></div>
@@ -858,30 +866,36 @@
    	#end
 		</div>
 	</div>
-	
+
 	<div id="allDivs">
 	
 	<div id="tabsContainer" class="cleanTopDiv" style="#if($translate == false)width: 100%;#else width: 550px; #end float:left;">
-	
 	<ul>
-        <li><a href="#contentVersionDiv"><span>$ui.getString('tool.contenttool.textContentTab')</span></a></li>
-        #if($this.hasAccessTo("ContentVersionEditor.Categories", true, false))
-        	<li><a href="#contentVersionCategoriesDiv"><span>$ui.getString('tool.contenttool.categoriesTab')</span></a></li>
-        #end
-        #if($this.hasAccessTo("ContentVersionEditor.Attachments", true, false))
-	        <li><a href="#contentVersionAssetsDiv"><span>$ui.getString('tool.contenttool.assetsTab')</span></a></li>
-        #end
-        <li><a href="#contentCoverDiv"><span>$ui.getString('tool.contenttool.coverTab')</span></a></li>
-   		#if($this.hasAccessTo("ContentVersionEditor.History", true, false))
-        	<li><a href="#contentHistoryDiv"><span>$ui.getString('tool.contenttool.contentHistoryTab')</span></a></li>
+		<li><a href="#contentVersionDiv"><span>$ui.getString('tool.contenttool.textContentTab')</span></a></li>
+
+		#if($this.hasAccessTo($categoriesInterceptionPoint, true, false))
+			<li><a href="#contentVersionCategoriesDiv"><span>$ui.getString('tool.contenttool.categoriesTab')</span></a></li>
 		#end
-		#if($this.hasAccessTo("ContentVersionEditor.References", true, false))
-	        <li><a href="#contentReferencesDiv"><span>$ui.getString('tool.contenttool.contentReferencesTab')</span></a></li>
-	    #end
-		#if($this.hasAccessTo("ContentVersionEditor.AccessRights", true, false))
-			#if($contentTypeDefinitionVO.name != "Meta info")
-		        <li><a href="#contentAccessRightsDiv"><span>$ui.getString('tool.contenttool.contentAccessRightsTab')</span></a></li>
-		        <li><a href="#contentVersionAccessRightsDiv"><span>$ui.getString('tool.contenttool.contentVersionAccessRightsTab')</span></a></li>
+		#if($this.hasAccessTo($attachmentsInterceptionPoint, true, false))
+			<li><a href="#contentVersionAssetsDiv"><span>$ui.getString('tool.contenttool.assetsTab')</span></a></li>
+		#end
+		#if($isMetainfoContent == false)
+			<li><a href="#contentCoverDiv"><span>$ui.getString('tool.contenttool.coverTab')</span></a></li>
+		#end
+		#if($isMetainfoContent == false)
+			#if($this.hasAccessTo("ContentVersionEditor.History", true, false))
+				<li><a href="#contentHistoryDiv"><span>$ui.getString('tool.contenttool.contentHistoryTab')</span></a></li>
+			#end
+		#end
+		#if($isMetainfoContent == false)
+			#if($this.hasAccessTo("ContentVersionEditor.References", true, false))
+				<li><a href="#contentReferencesDiv"><span>$ui.getString('tool.contenttool.contentReferencesTab')</span></a></li>
+			#end
+		#end
+		#if($isMetainfoContent == false)
+			#if($this.hasAccessTo("ContentVersionEditor.AccessRights", true, false))
+				<li><a href="#contentAccessRightsDiv"><span>$ui.getString('tool.contenttool.contentAccessRightsTab')</span></a></li>
+				<li><a href="#contentVersionAccessRightsDiv"><span>$ui.getString('tool.contenttool.contentVersionAccessRightsTab')</span></a></li>
 			#end
 		#end
     </ul>
@@ -889,7 +903,7 @@
 	<div id="contentVersionDiv" class="inlineTabDiv">
 		
 		<form method="post" name="editForm" id="editForm" action="UpdateContentVersion!standalone.action" style="float:left; width: 95%">
-			#if($contentTypeDefinitionVO.name == "Meta info" && $!siteNodeId)
+			#if($isMetainfoContent && $!siteNodeId)
 			<input type="hidden" name="siteNodeId" value="$!siteNodeId"/>
 			#end				
 			<input type="hidden" name="contentId" value="$!contentId"/>
@@ -970,7 +984,7 @@
 					
 		</div>
 	
-		#if($this.hasAccessTo("ContentVersionEditor.Categories", true, false))
+		#if($this.hasAccessTo($categoriesInterceptionPoint, true, false))
 	
 		<div id="contentVersionCategoriesDiv" class="inlineTabDiv">
 			
@@ -996,22 +1010,22 @@
 					<div style="clear: both;"></div>
 					<ul class="assignedEntities">
 						#set($relatedCategories = $this.getRelatedCategories($keyAttribute))
-    					#foreach($relation in $relatedCategories)
-                    	<li style="border-bottom: 1px solid #ccc;">
-                           	<a href="javascript:deleteCategory('$relation.contentCategoryId', '$contentId', '$languageId');"><img src="css/images/v3/cross.png" border="0"/></a>
-    						$relation.category.getLocalizedDisplayName($this.languageCode, "none") ($relation.category.name)
-    					</li>
-    					#end
-    					#if($relatedCategories.size() == 0)
-    					<li>
+						#foreach($relation in $relatedCategories)
+						<li style="border-bottom: 1px solid #ccc;">
+							<a href="javascript:deleteCategory('$relation.contentCategoryId', '$contentId', '$languageId');"><img src="css/images/v3/cross.png" border="0"/></a>
+							$relation.category.getLocalizedDisplayName($this.languageCode, "none") ($relation.category.name)
+						</li>
+						#end
+						#if($relatedCategories.size() == 0)
+						<li>
 							#if(!$contentVersionId)
 								$ui.getString("tool.contenttool.saveToRelateCategoriesPrefix") $keyAttribute
 							#else
 								$ui.getString("tool.contenttool.noCategoriesPrefix") $keyAttribute
 							#end
 						</li>
-    					#end
-					</ul>    					
+						#end
+					</ul>
 				#end
 			#else
 				<h4>There are no category attributes defined in this content type</h4>
@@ -1028,41 +1042,47 @@
 		</div>
 
 		#end
-		
-   		#if($this.hasAccessTo("ContentVersionEditor.Attachments", true, false))
-    	<div id="contentVersionAssetsDiv" class="inlineTabDiv">
-    		<iframe id="contentVersionAssetsFrame" name="contentVersionAssetsFrame" src="" border="0" width="100%" height="500px" frameborder="0"></iframe>
-    	</div>
-		#end
-		    		
-    	<div id="contentCoverDiv" class="inlineTabDiv">
-    		<iframe id="contentCoverFrame" src="" border="0" width="100%" height="500px" frameborder="0"></iframe>
-    	</div>
-    		
-		#if($this.hasAccessTo("ContentVersionEditor.History", true, false))
-    	<div id="contentHistoryDiv" class="inlineTabDiv">
-    		<iframe id="contentHistoryFrame" src="" border="0" width="100%" height="500px" frameborder="0"></iframe>
-    	</div>
+
+		#if($this.hasAccessTo($attachmentsInterceptionPoint, true, false))
+		<div id="contentVersionAssetsDiv" class="inlineTabDiv">
+			<iframe id="contentVersionAssetsFrame" name="contentVersionAssetsFrame" src="" border="0" width="100%" height="500px" frameborder="0"></iframe>
+		</div>
 		#end
 
-		#if($this.hasAccessTo("ContentVersionEditor.References", true, false))
-			<div id="contentReferencesDiv" class="inlineTabDiv">
-	    		<iframe id="contentReferencesFrame" src="" border="0" width="100%" height="500px" frameborder="0"></iframe>
-	    	</div>
+		#if($isMetainfoContent == false)
+		<div id="contentCoverDiv" class="inlineTabDiv">
+			<iframe id="contentCoverFrame" src="" border="0" width="100%" height="500px" frameborder="0"></iframe>
+		</div>
 		#end
-					
-		#if($contentTypeDefinitionVO.name != "Meta info")
-			#if($this.hasAccessTo("ContentVersionEditor.AccessRights", true, false))
-		    	<div id="contentAccessRightsDiv" class="inlineTabDiv">
-		    		<iframe id="contentAccessRightsFrame" src="" border="0" width="100%" height="500px" frameborder="0"></iframe>
-		    	</div>
-					
-		    	<div id="contentVersionAccessRightsDiv" class="inlineTabDiv">
-		    		<iframe id="contentVersionAccessRightsFrame" src="" border="0" width="100%" height="500px" frameborder="0"></iframe>
-		    	</div>
+
+		#if($isMetainfoContent == false)
+			#if($this.hasAccessTo("ContentVersionEditor.History", true, false))
+			<div id="contentHistoryDiv" class="inlineTabDiv">
+				<iframe id="contentHistoryFrame" src="" border="0" width="100%" height="500px" frameborder="0"></iframe>
+			</div>
 			#end
 		#end
-		    				
+
+		#if($isMetainfoContent == false)
+			#if($this.hasAccessTo("ContentVersionEditor.References", true, false))
+				<div id="contentReferencesDiv" class="inlineTabDiv">
+					<iframe id="contentReferencesFrame" src="" border="0" width="100%" height="500px" frameborder="0"></iframe>
+				</div>
+			#end
+		#end
+
+		#if($isMetainfoContent == false)
+			#if($this.hasAccessTo("ContentVersionEditor.AccessRights", true, false))
+				<div id="contentAccessRightsDiv" class="inlineTabDiv">
+					<iframe id="contentAccessRightsFrame" src="" border="0" width="100%" height="500px" frameborder="0"></iframe>
+				</div>
+					
+				<div id="contentVersionAccessRightsDiv" class="inlineTabDiv">
+					<iframe id="contentVersionAccessRightsFrame" src="" border="0" width="100%" height="500px" frameborder="0"></iframe>
+				</div>
+			#end
+		#end
+
 	</div><!-- End first tabs collection -->
 
 	#if($translate)


### PR DESCRIPTION
The content cover, references, and history tabs are now hidden.
It is also possible to hide the Categories and Attachment tabs using
InterceptionPoints (SiteNodeVersionEditor.[Categories, Attachments]).

This commit also introduces a setting for defining the content type
to use for Meta infos.
