### PR TITLE
Disables high contrast in CKEditor

### DIFF
--- a/src/webapp/cms/contenttool/v3/viewContentVersionStandaloneForFCKEditor.vm
+++ b/src/webapp/cms/contenttool/v3/viewContentVersionStandaloneForFCKEditor.vm
@@ -103,6 +103,10 @@
 
  		<script type="text/javascript" src="${root}/applications/ckeditor/ckeditor.js"></script>
 		<script type="text/javascript" src="${root}/script/editorForFCKEditor.js"></script>
+		<script type="text/javascript">
+			CKEDITOR.env.cssClass = CKEDITOR.env.cssClass.replace(" cke_hc", "");
+			CKEDITOR.env.hc = false;
+		</script>
 
 	#else
 	 	
@@ -541,7 +545,7 @@
 			#if($translate)
 			  	$("#otherLanguageTabsContainer").tabs({ cache: false, show:function() { resizeScrollArea(); }, select: function(e, ui) { loadFrame(ui.tab.href); }}  );
 			#end
-					
+
 			generateWYSIWYGS();
 	
 			$("#contentTypeAttributesTable :input").change(function () {


### PR DESCRIPTION
Firefox erroneously shows the editor in high contrast mode in some
circumstances. To prevent this we disable the feature all toghether.
