### PR TITLE
Removes non-useful options in EOS page tree menu

### DIFF
--- a/src/java/org/infoglue/cms/applications/PresentationStrings_en.properties
+++ b/src/java/org/infoglue/cms/applications/PresentationStrings_en.properties
@@ -2045,3 +2045,5 @@ tool.contenttool.importContent.suffix=\u0020-\u0020copy
 tool.structuretool.importPage.suffix=\u0020-\u0020copy
 
 tool.structuretool.toolbarV3.disableEditmodeNotAllowed=You cannot disable edit mode when there are unsaved changes. Save the page before disabeling edit mode.
+
+deliver.editOnSight.noActionAvailableHTML=No menu options available

--- a/src/java/org/infoglue/cms/applications/PresentationStrings_fr.properties
+++ b/src/java/org/infoglue/cms/applications/PresentationStrings_fr.properties
@@ -2015,3 +2015,5 @@ tool.contenttool.importContent.suffix=\u0020-\u0020copy
 tool.structuretool.importPage.suffix=\u0020-\u0020copy
 
 tool.structuretool.toolbarV3.disableEditmodeNotAllowed=You cannot disable edit mode when there are unsaved changes. Save the page before disabeling edit mode.
+
+deliver.editOnSight.noActionAvailableHTML=No menu options available

--- a/src/java/org/infoglue/cms/applications/PresentationStrings_sv.properties
+++ b/src/java/org/infoglue/cms/applications/PresentationStrings_sv.properties
@@ -2013,3 +2013,5 @@ tool.contenttool.importContent.suffix=\u0020-\u0020kopia
 tool.structuretool.importPage.suffix=\u0020-\u0020kopia
 
 tool.structuretool.toolbarV3.disableEditmodeNotAllowed=Du kan inte stänga av redigeringsläget när det finns osparade ändringar. Spara sidan innan du stänger av redigeringsläget.
+
+deliver.editOnSight.noActionAvailableHTML=Inga alternativ tillgängliga

--- a/src/java/org/infoglue/cms/controllers/kernel/impl/simple/InterceptionPointController.java
+++ b/src/java/org/infoglue/cms/controllers/kernel/impl/simple/InterceptionPointController.java
@@ -87,8 +87,9 @@ public class InterceptionPointController extends BaseController
 	    systemInterceptionPoints.put("Content.ChangeAccessRights", new InterceptionPointVO("Content", "Content.ChangeAccessRights", "Intercepts the attempt to change access rights", true));
 	    systemInterceptionPoints.put("Content.CreateVersion", new InterceptionPointVO("Content", "Content.CreateVersion", "Intercepts the creation of a new contentversion", true));
 	    systemInterceptionPoints.put("Content.ExpireDateComingUp", new InterceptionPointVO("Content", "Content.ExpireDateComingUp", "Intercepts the event of a content coming close to it's expire date", true));
-	    
-	    systemInterceptionPoints.put("Component.Select", new InterceptionPointVO("Component", "Component.Select", "Intercepts the read of a content when user want to list components to add in a slot", true));
+
+		systemInterceptionPoints.put("Component.Select", new InterceptionPointVO("Component", "Component.Select", "Intercepts the read of a content when user want to list components to add in a slot", true));
+		systemInterceptionPoints.put("Component.EditProperties", new InterceptionPointVO("Component", "Component.EditProperties", "This interception point limits who can see the properties menu in edit on sight", true));
 
 	    systemInterceptionPoints.put("ContentTypeDefinition.Read", new InterceptionPointVO("ContentTypeDefinition", "ContentTypeDefinition.Read", "This point checks access to read/use a content type definition", true));
 	    systemInterceptionPoints.put("ContentVersion.Delete", new InterceptionPointVO("ContentVersion", "ContentVersion.Delete", "Intercepts the deletion of a contentversion", true));
@@ -137,6 +138,7 @@ public class InterceptionPointController extends BaseController
 		systemInterceptionPoints.put("ComponentEditor.CreateSubpage", new InterceptionPointVO("ComponentEditor", "ComponentEditor.CreateSubpage", "This interception point limits who can see the create subpage menu in edit on sight", false));
 		systemInterceptionPoints.put("ComponentEditor.EditPageMetadata", new InterceptionPointVO("ComponentEditor", "ComponentEditor.EditPageMetadata", "This interception point limits who can see the edit page meta info menu in edit on sight", false));
 		systemInterceptionPoints.put("ComponentEditor.SavePageTemplate", new InterceptionPointVO("ComponentEditor", "ComponentEditor.SavePageTemplate", "This interception point limits who can see the save page template menu in edit on sight", false));
+		systemInterceptionPoints.put("ComponentEditor.MySettings", new InterceptionPointVO("ComponentEditor", "ComponentEditor.MySettings", "This interception point limits who can see the properties menu in edit on sight", false));
 		
 		systemInterceptionPoints.put("ComponentEditor.NotifyUserOfPage", new InterceptionPointVO("ComponentEditor", "ComponentEditor.NotifyUserOfPage", "This interception point limits who can see the notify user menu in edit on sight", false));
 		systemInterceptionPoints.put("ComponentEditor.ContentNotifications", new InterceptionPointVO("ComponentEditor", "ComponentEditor.ContentNotifications", "This interception point limits who can see the content notification info menu in edit on sight", false));

--- a/src/java/org/infoglue/deliver/invokers/DecoratedComponentBasedHTMLPageInvoker.java
+++ b/src/java/org/infoglue/deliver/invokers/DecoratedComponentBasedHTMLPageInvoker.java
@@ -317,7 +317,6 @@ public class DecoratedComponentBasedHTMLPageInvoker extends ComponentBasedHTMLPa
 			boolean hasAccessToDeleteComponent 	= AccessRightController.getController().getIsPrincipalAuthorized(templateController.getDatabase(), principal, "ComponentEditor.DeleteComponent", "" + component.getContentId() + "_" + component.getSlotName());
 			boolean hasAccessToChangeComponent 	= AccessRightController.getController().getIsPrincipalAuthorized(templateController.getDatabase(), principal, "ComponentEditor.ChangeComponent", "" + component.getContentId() + "_" + component.getSlotName());
 			boolean hasSaveTemplateAccess 		= AccessRightController.getController().getIsPrincipalAuthorized(templateController.getDatabase(), principal, "ComponentEditor.SavePageTemplate", true, false, true);
-
 		    boolean hasSubmitToPublishAccess 	= AccessRightController.getController().getIsPrincipalAuthorized(templateController.getDatabase(), principal, "ComponentEditor.SubmitToPublish", true, false, true);
 		    boolean hasPageStructureAccess 		= AccessRightController.getController().getIsPrincipalAuthorized(templateController.getDatabase(), principal, "ComponentEditor.PageStructure", true, false, true);
 		    boolean hasOpenInNewWindowAccess 	= AccessRightController.getController().getIsPrincipalAuthorized(templateController.getDatabase(), principal, "ComponentEditor.OpenInNewWindow", true, false, true);
@@ -435,6 +434,7 @@ public class DecoratedComponentBasedHTMLPageInvoker extends ComponentBasedHTMLPa
 			String editInlineHTML 					= getLocalizedString(locale, "deliver.editOnSight.editContentInlineLabel");
 			String propertiesHTML 					= getLocalizedString(locale, "deliver.editOnSight.propertiesHTML");
 			String favouriteComponentsHeader		= getLocalizedString(locale, "tool.common.favouriteComponentsHeader");
+			String noActionAvailableHTML 			= getLocalizedString(locale, "deliver.editOnSight.noActionAvailableHTML");
 	    	
 			String notifyLabel 						= getLocalizedString(locale, "deliver.editOnSight.notifyLabel");
 	    	String subscribeToContentLabel 			= getLocalizedString(locale, "deliver.editOnSight.subscribeToContentLabel");
@@ -503,6 +503,7 @@ public class DecoratedComponentBasedHTMLPageInvoker extends ComponentBasedHTMLPa
 		    extraBody = extraBody.replaceAll("\\$viewSource", viewSourceHTML);
 			extraBody = extraBody.replaceAll("\\$propertiesHTML", propertiesHTML);
 			extraBody = extraBody.replaceAll("\\$favouriteComponentsHeader", favouriteComponentsHeader);
+			extraBody = extraBody.replaceAll("\\$noActionAvailableHTML", noActionAvailableHTML);
 
 			extraBody = extraBody.replaceAll("\\$\\{deliver.editOnSight.pendingPageApproval.title\\}", getLocalizedString(locale, "deliver.editOnSight.pendingPageApproval.title"));
 			extraBody = extraBody.replaceAll("\\$\\{deliver.editOnSight.pendingContentApproval.title\\}", getLocalizedString(locale, "deliver.editOnSight.pendingContentApproval.title"));
@@ -2060,6 +2061,7 @@ public class DecoratedComponentBasedHTMLPageInvoker extends ComponentBasedHTMLPa
 	    boolean hasCreateSubpageAccess 		= AccessRightController.getController().getIsPrincipalAuthorized(templateController.getDatabase(), principal, "ComponentEditor.CreateSubpage", true, false, true);
 	    boolean hasCreatePagesAccess 		= AccessRightController.getController().getIsPrincipalAuthorized(templateController.getDatabase(), principal, "Common.CreatePage", true, false, true);
 	    boolean hasEditPageMetadataAccess 	= AccessRightController.getController().getIsPrincipalAuthorized(templateController.getDatabase(), principal, "ComponentEditor.EditPageMetadata", true, false, true);
+	    boolean hasAccessToEditProperties	= AccessRightController.getController().getIsPrincipalAuthorized(templateController.getDatabase(), principal, "Component.EditProperties", "" + component.getContentId(), true);
 
 	    boolean showNotifyUserOfPage 		= AccessRightController.getController().getIsPrincipalAuthorized(templateController.getDatabase(), principal, "ComponentEditor.NotifyUserOfPage", true, false, true);
 	    boolean showContentNotifications 	= AccessRightController.getController().getIsPrincipalAuthorized(templateController.getDatabase(), principal, "ComponentEditor.ContentNotifications", true, false, true);
@@ -2099,6 +2101,7 @@ public class DecoratedComponentBasedHTMLPageInvoker extends ComponentBasedHTMLPa
 		    sb.append("window.hasAccessToAddComponent" + component.getId() + "_" + component.getSlotName().replaceAll("[^0-9,a-z,A-Z]", "_") + " = " + hasAccessToAddComponent + ";");
 			sb.append("window.hasAccessToDeleteComponent" + component.getId() + "_" + component.getSlotName().replaceAll("[^0-9,a-z,A-Z]", "_") + " = " + hasAccessToDeleteComponent + ";");
 			sb.append("window.hasAccessToChangeComponent" + component.getId() + "_" + component.getSlotName().replaceAll("[^0-9,a-z,A-Z]", "_") + " = " + hasAccessToChangeComponent + ";");
+			sb.append("window.hasAccessToEditProperties" + component.getId() + "_" + component.getSlotName().replaceAll("[^0-9,a-z,A-Z]", "_") + " = " + hasAccessToEditProperties + ";");
 			sb.append("window.hasAccessToAccessRights = " + hasAccessToAccessRights + ";");
 			sb.append("</script>");
 			return sb.toString();
@@ -2220,9 +2223,12 @@ public class DecoratedComponentBasedHTMLPageInvoker extends ComponentBasedHTMLPa
 		//if(hasMoveComponentUpAccess || hasMoveComponentDownAccess)
 		//	sb.append("<div class=\"igmenuitems linkEnableSortComponent\" onclick=\"enableComponentSort(" + component.getId() + ", '" + component.getSlotName() + "', " + (component.getParentComponent() != null ? component.getParentComponent().getId() : "-1") + "); return false;\"><a href='javascript:return false;'>" + enableSortComponentsHTML + "</a></div>");
 
-		sb.append("<div style='border-top: 1px solid #bbb; height: 1px; margin: 0px; padding: 0px; line-height: 1px;'></div>");
-		sb.append("<div class=\"igmenuitems linkComponentProperties\" onclick=\"showComponent(event);\"><a name='void'>" + propertiesHTML + "</a></div>");
-		if(hasPageStructureAccess || hasOpenInNewWindowAccess || hasViewSourceAccess)
+		if(hasAccessToEditProperties)
+		{
+			sb.append("<div style='border-top: 1px solid #bbb; height: 1px; margin: 0px; padding: 0px; line-height: 1px;'></div>");
+			sb.append("<div class=\"igmenuitems linkComponentProperties\" onclick=\"showComponent(event);\"><a name='void'>" + propertiesHTML + "</a></div>");
+		}
+		if(hasPageStructureAccess || hasOpenInNewWindowAccess || hasViewSourceAccess || hasMySettingsAccess)
 			sb.append("<div style='border-top: 1px solid #bbb; height: 1px; margin:0px; padding: 0px; line-height: 1px;'></div>");
 		if(hasPageStructureAccess)
 			sb.append("<div class=\"igmenuitems linkPageComponents\" onclick=\"javascript:toggleDiv('pageComponents');\"><a href='javascript:void(0);'>" + pageComponentsHTML + "</a></div>");
@@ -2240,6 +2246,7 @@ public class DecoratedComponentBasedHTMLPageInvoker extends ComponentBasedHTMLPa
 		sb.append("window.hasAccessToAddComponent" + component.getId() + "_" + component.getSlotName().replaceAll("[^0-9,a-z,A-Z]", "_") + " = " + hasAccessToAddComponent + ";\n");
 		sb.append("window.hasAccessToDeleteComponent" + component.getId() + "_" + component.getSlotName().replaceAll("[^0-9,a-z,A-Z]", "_") + " = " + hasAccessToDeleteComponent + ";\n");
 		sb.append("window.hasAccessToChangeComponent" + component.getId() + "_" + component.getSlotName().replaceAll("[^0-9,a-z,A-Z]", "_") + " = " + hasAccessToChangeComponent + ";\n");
+		sb.append("window.hasAccessToEditProperties" + component.getId() + "_" + component.getSlotName().replaceAll("[^0-9,a-z,A-Z]", "_") + " = " + hasAccessToEditProperties + ";\n");
 		sb.append("window.hasAccessToAccessRights = " + hasAccessToAccessRights + ";\n");
 		if(hasMoveComponentUpAccess || hasMoveComponentDownAccess)
 			sb.append("enableComponentSort(" + component.getId() + ", '" + component.getSlotName() + "', " + (component.getParentComponent() != null ? component.getParentComponent().getId() : "-1") + ");\n");

--- a/src/webapp/css/componentEditor.css
+++ b/src/webapp/css/componentEditor.css
@@ -186,6 +186,12 @@ Component palette classes
 	text-decoration: underline;
 	color: black;
 }
+.igmenuitems.noActionMenuItem a {
+	font-style: italic;
+}
+.igmenuitems.noActionMenuItem a:hover {
+	text-decoration: none;
+}
 
 /*
 This can be replaced by componentEditor.js:highighi5 and lowlighti5

--- a/src/webapp/preview/pageComponentEditorBody.vm
+++ b/src/webapp/preview/pageComponentEditorBody.vm
@@ -1,15 +1,9 @@
 <div id="genericDialog" style="display: none;"><h3>Saving</h3><p>Saving page and refreshing the view - please wait.</p></div>
 <div id="emptySlotMenu" class="skin0">
-<div class="igmenuitems linkPublish" onclick="submitToPublish($siteNodeId, $contentId, $languageId, $repositoryId, '$originalFullURL');"><a href='#'>$submitToPublishHTML</a></div>
-<div class="igmenuitems linkNotify" onclick="openInlineDivImpl('$notifyUrl', 700, 750, true, true);"><a href='#'>$notifyHTML</a></div>
-<div class="igmenuitems linkTakePage" onclick="openInlineDivImpl('$pageSubscriptionUrl', 700, 750, true, true);"><a name='subscribePage'>$subscribeToPageHTML</a></div>
 <div class="igmenuitems linkAddComponent" onclick="insertComponent();"><a href='#'>$addComponentHTML</a></div>
-<div class="igmenuitems linkCreatePageTemplate" onclick="$saveTemplateUrl"><a href='#'>$savePageTemplateHTML</a></div>
 <hr id="emptySlotMenuTopSeparator" style="border:0px; border-top:1px solid #bbb; margin-top:4px; margin-bottom:4px;"/>
 <div id="accessRightsMenuItem" class="igmenuitems linkAccessRights" onclick="setAccessRights(slotName, slotContentId);"><a href='#'>$accessRightsHTML</a></div>
-<div class="igmenuitems linkPageComponents" onclick="toggleDiv('pageComponents');"><a href='javascript:void(0);'>$pageComponents</a></div>
-<div class="igmenuitems linkOpenInNewWindow" onclick="window.open(document.location.href,'PageComponents','');"><a href='#'>$componentEditorInNewWindowHTML</a></div>
-<div class="igmenuitems linkViewSource"><a href='javascript:viewSource();'>$viewSource</a></div>
+<div id="noActionAvailableSlotMenuItem" class="igmenuitems noActionMenuItem"><a href='#'>$noActionAvailableHTML</a></div>
 </div>
 
 <div id="componentMenu" class="skin0">
@@ -30,14 +24,10 @@
 <div id="componentInTreeMenu" class="skin0">
 	<div id="deleteComponentInTreeMenuItem" class="igmenuitems linkDeleteComponent" onclick="deleteComponent('$confirmDeleteLabel');"><a href='#'>$deleteComponentHTML</a></div>
 	<div id="changeComponentInTreeMenuItem" class="igmenuitems linkChangeComponent" onclick="changeComponent();"><a href='#'>$changeComponentHTML</a></div>
-	<div class="igmenuitems linkCreatePageTemplate" onclick="$saveTemplateUrl"><a href='#'>$savePageTemplateHTML</a></div>
-	<div class="igmenuitems linkCreatePageTemplate" onclick="$savePartTemplateUrl"><a href='#'>$savePagePartTemplateHTML</a></div>
+	<div id="createPageTemplateInTreeMenuItem" class="igmenuitems linkCreatePageTemplate" onclick="$savePartTemplateUrl"><a href='#'>$savePagePartTemplateHTML</a></div>
 	<hr id="componentInTreeMenuTopSeparator" style="border:0px; border-top:1px solid #bbb; margin-top:4px; margin-bottom:4px;"/>
-	<div class="igmenuitems linkComponentProperties" onclick="javascript:showComponent();"><a href='#'>$propertiesHTML</a></div>
-	<hr id="emptySlotMenuMiddleSeparator" style="border:0px; border-top:1px solid #bbb; margin-top:4px; margin-bottom:4px;"/>
-	<div class="igmenuitems linkPageComponents" onclick="toggleDiv('pageComponents');"><a href='#'>$pageComponents</a></div>
-	<div class="igmenuitems linkOpenInNewWindow" onclick="window.open(document.location.href,'PageComponents','');"><a href='#'>$componentEditorInNewWindowHTML</a></div>
-	<div class="igmenuitems linkViewSource"><a href='javascript:viewSource();'>$viewSource</a></div>
+	<div id="componentPropertiesInTreeMenuItem" class="igmenuitems linkComponentProperties" onclick="javascript:showComponent();"><a href='#'>$propertiesHTML</a></div>
+	<div id="noActionAvailableMenuItem" class="igmenuitems noActionMenuItem"><a href='#'>$noActionAvailableHTML</a></div>
 </div>
 
 <div id="pageToolbar" class="editOnSightFooterToolbar buttonPane">

--- a/src/webapp/script/componentEditor.js
+++ b/src/webapp/script/componentEditor.js
@@ -597,67 +597,102 @@ function showComponentMenu(event, element, compId, anInsertUrl, anDeleteUrl, anC
 	return false;
 }
 
-
 function showComponentInTreeMenu(event, element, compId, anInsertUrl, anDeleteUrl, anChangeUrl, slotId, slotContentIdVar, aActiveComponentName) 
 {
+	var checkAccessAndEnable = function(accessVarName, domId)
+	{
+		var changeAccess = eval(accessVarName);
+		if(changeAccess)
+		{
+			document.getElementById(domId).style.display = "block";
+			return true;
+		}
+		else
+		{
+			document.getElementById(domId).style.display = "none";
+			return false;
+		}
+	}
+
+	hidepreviousmenues();
+
 	activeMenuId 		= "componentInTreeMenu";
 	slotName 			= slotId;
 	slotContentId 		= slotContentIdVar;
 	activeComponentName = aActiveComponentName;
-	
-	//alert("slotId:" + slotId);
-	//alert("compId:" + compId);
-	
+
 	try
 	{
-		var access = eval("window.hasAccessToDeleteComponent" + compId + "_" + convertName(slotName)); 
-	    //alert("access:" + access);
-	    if(access) 
-	    {
-	    	document.getElementById("deleteComponentInTreeMenuItem").style.display = "block";
-	    	document.getElementById("componentInTreeMenuTopSeparator").style.display = "block";
+		var componentIdentifer = compId + "_" + convertName(slotName);
+		var hasTopSectionItems = false;
+		var hasBottomSectionItems = false;
+		var access = eval("window.hasAccessToDeleteComponent" + componentIdentifer);
+		if(access)
+		{
+			document.getElementById("deleteComponentInTreeMenuItem").style.display = "block";
+			hasTopSectionItems = true;
 		}
 		else
 		{
-	    	document.getElementById("deleteComponentInTreeMenuItem").style.display = "none";
-	    	document.getElementById("componentInTreeMenuTopSeparator").style.display = "none";
-	    }
+			document.getElementById("deleteComponentInTreeMenuItem").style.display = "none";
+		}
 
 		var changeAccess = eval("window.hasAccessToChangeComponent" + compId + "_" + convertName(slotName)); 
-	    //alert("changeAccess:" + changeAccess);
-	    if(changeAccess) 
-	    {
-	    	document.getElementById("changeComponentInTreeMenuItem").style.display = "block";
-	    }
+		if(changeAccess)
+		{
+			hasTopSectionItems = true;
+			document.getElementById("changeComponentInTreeMenuItem").style.display = "block";
+		}
 		else
 		{
-	    	document.getElementById("changeComponentInTreeMenuItem").style.display = "none";
-	    }
+			document.getElementById("changeComponentInTreeMenuItem").style.display = "none";
+		}
+		hasTopSectionItems = checkAccessAndEnable("window.hasAccessToSavePageTemplate", "createPageTemplateInTreeMenuItem") || hasTopSectionItems;
+		hasBottomSectionItems = checkAccessAndEnable("window.hasAccessToEditProperties" + componentIdentifer, "componentPropertiesInTreeMenuItem");
+		if (hasTopSectionItems && hasBottomSectionItems)
+		{
+			document.getElementById("componentInTreeMenuTopSeparator").style.display = "block";
+		}
+		else
+		{
+			document.getElementById("componentInTreeMenuTopSeparator").style.display = "none";
+		}
 	}
 	catch(e)
 	{
-		//alert("Error:" + e);
+		if (typeof console === "object")
+		{
+			console.log("Error when generating component menu in tree.", e);
+		}
+	}
+
+	var childrenHiddenFilter = function() {return $(this).css("display") === "block";};
+	if ($("#componentInTreeMenu").children(":not(#noActionAvailableMenuItem)").filter(childrenHiddenFilter).length === 0)
+	{
+		$("#noActionAvailableMenuItem").css("display", "block");
+	}
+	else
+	{
+		$("#noActionAvailableMenuItem").css("display", "none");
 	}
 
 	componentId = compId;
 	insertUrl = anInsertUrl;
 	deleteUrl = anDeleteUrl;
 	changeUrl = anChangeUrl;
-	//alert("componentId" + componentId);
-    //alert("changeUrl:" + changeUrl);
-    
-    document.body.onclick = hidemenuie5;
+
+	document.body.onclick = hidemenuie5;
 	getActiveMenuDiv().className = menuskin;
-	
+
 	clientX = getEventPositionX(event);
 	clientY = getEventPositionY(event);
-	
+
 	var rightedge = document.body.clientWidth - clientX;
 	//var bottomedge = document.body.clientHeight - clientY;
 	var bottomedge = getWindowHeight() - clientY;
 
 	menuDiv = getActiveMenuDiv();
-	
+
 	/*
 	if (rightedge < menuDiv.offsetWidth)
 		newLeft = (document.body.scrollLeft + clientX - menuDiv.offsetWidth);
@@ -705,84 +740,60 @@ function showEmptySlotMenu(slotId, event, compId, anInsertUrl, slotContentIdVar)
 	
 	try
 	{
-	    if(window.hasAccessToPageNotifications) 
-	    	$(".linkTakePage").css("display","block");
-		else
-	    	$(".linkTakePage").css("display","none");
-
-	    if(window.hasAccessToContentNotifications) 
-	    	$(".linkTakeContent").css("display","block");
-		else
-	    	$(".linkTakeContent").css("display","none");
-
-	    if(window.hasAccessToSavePageTemplate) 
-	    	$(".linkCreatePageTemplate").css("display","block");
-		else
-	    	$(".linkCreatePageTemplate").css("display","none");
-
-	    if(window.hasPageStructureAccess) 
-	    	$(".linkPageComponents").css("display", "block");
-		else
-	    	$(".linkPageComponents").css("display", "none");
-
-	    if(window.hasOpenInNewWindowAccess) 
-	    	$(".linkOpenInNewWindow").css("display","block");
-		else
-	    	$(".linkOpenInNewWindow").css("display","none");
-
-	    if(window.hasAccessToViewSource) 
-	    	$(".linkViewSource").css("display","block");
-		else
-	    	$(".linkViewSource").css("display","none");
-	    
-	    
-	    var access = eval("window.hasAccessToAddComponent" + convertName(compId)); 
-	    if(access) 
-	    {
-	    	$(".linkAddComponent").css("display", "block");
-	    	$("#emptySlotMenuTopSeparator").css("display", "block");
+		var showTopItem = false;
+		var access = eval("window.hasAccessToAddComponent" + convertName(compId));
+		if(access)
+		{
+			$(".linkAddComponent").css("display", "block");
+			$("#emptySlotMenuTopSeparator").css("display", "block");
+			showTopItem = true;
 		}
 		else
 		{
 			$(".linkAddComponent").css("display", "none");
-	    	$("#emptySlotMenuTopSeparator").css("display", "none");
-	    }
+		}
 
 		var accessToAccessRights = eval("window.hasAccessToAccessRights"); 
-	    if(accessToAccessRights) 
-	    {
-	    	document.getElementById("accessRightsMenuItem").style.display = "block";
+		if(accessToAccessRights)
+		{
+			if (showTopItem)
+			{
+				$("#emptySlotMenuTopSeparator").css("display", "block");
+			}
+			else
+			{
+				$("#emptySlotMenuTopSeparator").css("display", "none");
+			}
+			document.getElementById("accessRightsMenuItem").style.display = "block";
 		}
 		else
 		{
-	    	document.getElementById("accessRightsMenuItem").style.display = "none";
-	    }
-
-		var hasAccessToChangeComponent = eval("window.hasAccessToChangeComponent" + convertName(compId)); 
-	    //alert("hasAccessToChangeComponent:" + hasAccessToChangeComponent);
-	    if(hasAccessToChangeComponent) 
-	    {
-	    	document.getElementById("changeComponentMenuItem").style.display = "block";
+			$("#emptySlotMenuTopSeparator").css("display", "none");
+			document.getElementById("accessRightsMenuItem").style.display = "none";
 		}
-		else
-		{
-	    	document.getElementById("changeComponentMenuItem").style.display = "none";
-	    }
 	}
 	catch(e)
 	{
-		//alert("Error:" + e);
+		if (typeof console === "object")
+		{
+			console.log("Error when generating menu for slot in tree.", e);
+		}
 	}
-	 
+
+	var childrenHiddenFilter = function() {return $(this).css("display") === "block";};
+	if ($("#emptySlotMenu").children(":not(#noActionAvailableSlotMenuItem)").filter(childrenHiddenFilter).length === 0)
+	{
+		$("#noActionAvailableSlotMenuItem").css("display", "block");
+	}
+	else
+	{
+		$("#noActionAvailableSlotMenuItem").css("display", "none");
+	}
+
 	slotId = compId;
 	insertUrl = anInsertUrl;
-	//alert("slotId:" + slotId);
-	//alert("slotName:" + slotName);
-	//alert("slotContentId:" + slotContentId);
-	//alert("CompId:" + compId);
-    //alert(insertUrl);
-	
-    document.body.onclick = hidemenuie5;
+
+	document.body.onclick = hidemenuie5;
 	getActiveMenuDiv().className = menuskin;
 	
 	clientX = getEventPositionX(event);
@@ -1736,7 +1747,7 @@ function setAccessRights(slotId, slotContentId)
 	//alert("slotId in setAccessRights:" + slotId);
 	//alert("currentUrl:" + document.location.href);
 	//alert("slotId: " + slotId + " - slotContentId:" + slotContentId);
-	openInlineDiv(componentEditorUrl + "ViewAccessRights!V3.action?interceptionPointCategory=ComponentEditor&extraParameters=" + slotContentId + "_" + slotId + "&returnAddress=ViewInlineOperationMessages.action&originalAddress=refreshParent", 800, 600, true);
+	openInlineDiv(componentEditorUrl + "ViewAccessRights!V3.action?interceptionPointCategory=ComponentEditor&extraParameters=" + slotContentId + "_" + slotId + "&returnAddress=ViewInlineOperationMessages.action&originalAddress=refreshParent", 600, 800, true);
 }
 
 function deleteComponent(aConfirmText) 


### PR DESCRIPTION
= Options after clean up.
== Slot menu
- Add component
- Access rights

== Component menu
- Delete component
- Change component
- Create page part template
- Component properties

All remaining options can be disabled through IPs.
The menus can now be empty with certain configurations. Therefore a
concept for handling this has been added. Now a "no action" menu option is
displayed if no real menu options are available to the user.

Also adds IP for disabling the component properties menu options. This IP
can be applied on a slot by slot basis.
