### PR TITLE
Better message on validation error in EOS

### DIFF
--- a/src/java/org/infoglue/cms/applications/common/actions/AbstractFormAction.java
+++ b/src/java/org/infoglue/cms/applications/common/actions/AbstractFormAction.java
@@ -102,7 +102,7 @@ public abstract class AbstractFormAction extends AbstractAction implements Comma
   /**
    * <todo>Move to a ConstraintExceptionHelper class?</todo>
    */
-  private String getLocalizedErrorMessage(Locale locale, String errorCode) {
+  protected String getLocalizedErrorMessage(Locale locale, String errorCode) {
     // <todo>fetch packagename from somewhere</todo>
     final StringManager stringManager = StringManagerFactory.getPresentationStringManager("org.infoglue.cms.entities", locale);
 

--- a/src/java/org/infoglue/cms/applications/common/actions/WebworkAbstractAction.java
+++ b/src/java/org/infoglue/cms/applications/common/actions/WebworkAbstractAction.java
@@ -30,6 +30,7 @@ import java.util.Enumeration;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.MissingResourceException;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -346,19 +347,20 @@ public abstract class WebworkAbstractAction implements Action, ServletRequestAwa
 	}
 
 	/**
-     * <todo>Move to a ConstraintExceptionHelper class?</todo>
-     */
-  
-  	private String getLocalizedErrorMessage(Locale locale, String errorCode) 
-  	{
-    	// <todo>fetch packagename from somewhere</todo>
-    	StringManager stringManager = StringManagerFactory.getPresentationStringManager("org.infoglue.cms.entities", locale);
+	 * <todo>Move to a ConstraintExceptionHelper class?</todo>
+	 * @throws NullPointerException		If any of the arguments are null
+	 * @throws MissingResourceException	If no key matches the given <em>errorCode</em>
+	 */
+	protected String getLocalizedErrorMessage(Locale locale, String errorCode) throws NullPointerException, MissingResourceException
+	{
+		// <todo>fetch packagename from somewhere</todo>
+		StringManager stringManager = StringManagerFactory.getPresentationStringManager("org.infoglue.cms.entities", locale);
 
-	    // check if a specific error message exists - <todo/>	
-  	  	// nah, use the general error message
-    	return stringManager.getString(errorCode);
-  	}
-  
+		// check if a specific error message exists - <todo/>
+		// nah, use the general error message
+		return stringManager.getString(errorCode);
+	}
+
 
   	public String getLocalizedString(Locale locale, String key) 
   	{

--- a/src/java/org/infoglue/cms/applications/structuretool/actions/ViewStructureToolToolBarAction.java
+++ b/src/java/org/infoglue/cms/applications/structuretool/actions/ViewStructureToolToolBarAction.java
@@ -527,7 +527,7 @@ public class ViewStructureToolToolBarAction extends InfoGlueAbstractAction
 	/**
 	 * <todo>Move to a ConstraintExceptionHelper class?</todo>
 	 */
-	private String getLocalizedErrorMessage(Locale locale, String errorCode) 
+	protected String getLocalizedErrorMessage(Locale locale, String errorCode)
 	{
 		final StringManager stringManager = StringManagerFactory.getPresentationStringManager("org.infoglue.cms.entities", locale);
 		return stringManager.getString(errorCode);

--- a/src/java/org/infoglue/cms/controllers/kernel/impl/simple/ContentVersionController.java
+++ b/src/java/org/infoglue/cms/controllers/kernel/impl/simple/ContentVersionController.java
@@ -1675,7 +1675,7 @@ public class ContentVersionController extends BaseController
         }
         catch(ConstraintException ce)
         {
-        	logger.warn("Validation error:" + ce, ce);
+			logger.info("Validation error:" + ce, ce);
             rollbackTransaction(db);
             throw ce;
         }
@@ -1807,7 +1807,7 @@ public class ContentVersionController extends BaseController
 		}
 		catch(ConstraintException ce)
 		{
-			logger.warn("Validation error:" + ce, ce);
+			logger.info("Validation error:" + ce, ce);
 			rollbackTransaction(db);
 			throw ce;
 		}

--- a/src/java/org/infoglue/cms/controllers/kernel/impl/simple/SiteNodeVersionController.java
+++ b/src/java/org/infoglue/cms/controllers/kernel/impl/simple/SiteNodeVersionController.java
@@ -228,7 +228,6 @@ public class SiteNodeVersionController extends BaseController
 	    	if(i>98)
 	    		break;
 
-    		System.out.print(","+entityId);
     		i++;
     	}
 

--- a/src/webapp/script/componentEditor.js
+++ b/src/webapp/script/componentEditor.js
@@ -1494,10 +1494,10 @@ function saveAttribute(selectedContentId, selectedLanguageId, selectedAttributeN
 				   alert("You are not logged in properly to the administrative tools - please log in again.");
 				   window.open("" + componentEditorUrl + "ViewCMSTool!loginStandalone.action", "Login", "width=400,height=420");
 			   }
-			   else if(XMLHttpRequest.status == 406)
-			   {
-				   alert("The value must not be empty - update failed");
-			   }
+				else if(XMLHttpRequest.status == 406)
+				{
+					alert(XMLHttpRequest.responseText);
+				}
 			   else
 			   {
 				   alert("Update failed!");
@@ -1542,9 +1542,9 @@ function saveAttribute(selectedContentId, selectedLanguageId, selectedAttributeN
 				   window.open("" + componentEditorUrl + "ViewCMSTool!loginStandalone.action", "Login", "width=400,height=420");
 			   }
 			   else if(XMLHttpRequest.status == 406)
-			   {
-				   alert("The value must not be empty - update failed");
-			   }
+				{
+					alert(XMLHttpRequest.responseText);
+				}
 			   else
 			   {
 				   alert("Update failed!");


### PR DESCRIPTION
The update-content-attribute action now send the Validation message as an
error text when a validation error occurs. The JS receiving the error
display the error message to the user.

If the constraint exception is a required field exception the offending
field name is also included in the alert message (this is a new feature).
