### PR TITLE
Trash can now filters based on user rights #93

### DIFF
--- a/src/java/org/infoglue/cms/applications/common/actions/TrashcanAction.java
+++ b/src/java/org/infoglue/cms/applications/common/actions/TrashcanAction.java
@@ -64,9 +64,9 @@ public class TrashcanAction extends InfoGlueAbstractAction
 	
 	protected String doExecute() throws Exception
     {
-		this.repositoriesMarkedForDeletion = RepositoryController.getController().getRepositoryVOListMarkedForDeletion();
-		this.contentsMarkedForDeletion = ContentController.getContentController().getContentVOListMarkedForDeletion(repositoryFilter);
-		this.siteNodesMarkedForDeletion = SiteNodeController.getController().getSiteNodeVOListMarkedForDeletion(repositoryFilter);
+		this.repositoriesMarkedForDeletion = RepositoryController.getController().getRepositoryVOListMarkedForDeletion(getInfoGluePrincipal());
+		this.contentsMarkedForDeletion = ContentController.getContentController().getContentVOListMarkedForDeletion(repositoryFilter, getInfoGluePrincipal());
+		this.siteNodesMarkedForDeletion = SiteNodeController.getController().getSiteNodeVOListMarkedForDeletion(repositoryFilter, getInfoGluePrincipal());
 		
 		return Action.SUCCESS;
     }
@@ -130,9 +130,9 @@ public class TrashcanAction extends InfoGlueAbstractAction
     {
 		validateSecurityCode();
 
-		this.repositoriesMarkedForDeletion = RepositoryController.getController().getRepositoryVOListMarkedForDeletion();
-		this.contentsMarkedForDeletion = ContentController.getContentController().getContentVOListMarkedForDeletion(this.repositoryFilter);
-		this.siteNodesMarkedForDeletion = SiteNodeController.getController().getSiteNodeVOListMarkedForDeletion(this.repositoryFilter);
+		this.repositoriesMarkedForDeletion = RepositoryController.getController().getRepositoryVOListMarkedForDeletion(getInfoGluePrincipal());
+		this.contentsMarkedForDeletion = ContentController.getContentController().getContentVOListMarkedForDeletion(this.repositoryFilter, getInfoGluePrincipal());
+		this.siteNodesMarkedForDeletion = SiteNodeController.getController().getSiteNodeVOListMarkedForDeletion(this.repositoryFilter, getInfoGluePrincipal());
 
 		Iterator<SiteNodeVO> siteNodesMarkedForDeletionIterator = siteNodesMarkedForDeletion.iterator();
 		while(siteNodesMarkedForDeletionIterator.hasNext())

--- a/src/java/org/infoglue/cms/controllers/kernel/impl/simple/ContentController.java
+++ b/src/java/org/infoglue/cms/controllers/kernel/impl/simple/ContentController.java
@@ -3529,7 +3529,7 @@ public class ContentController extends BaseController
         }
     }  
 
-	public List<ContentVO> getContentVOListMarkedForDeletion(Integer repositoryId) throws SystemException, Bug
+	public List<ContentVO> getContentVOListMarkedForDeletion(Integer repositoryId, InfoGluePrincipal infoGluePrincipal) throws SystemException, Bug
 	{
 		Database db = CastorDatabaseService.getDatabase();
 		
@@ -3552,9 +3552,16 @@ public class ContentController extends BaseController
 			while(results.hasMore()) 
             {
 				Content content = (Content)results.next();
-				content.getValueObject().getExtraProperties().put("repositoryMarkedForDeletion", content.getRepository().getIsDeleted());
-				contentVOListMarkedForDeletion.add(content.getValueObject());
-            }
+				Integer contentRepositoryId = content.getRepositoryId();
+				Integer contentId = content.getContentId();
+
+				if((AccessRightController.getController().getIsPrincipalAuthorized(db, infoGluePrincipal, "Repository.Read", contentRepositoryId.toString()) && AccessRightController.getController().getIsPrincipalAuthorized(db, infoGluePrincipal, "Repository.Write", contentRepositoryId.toString()))
+					&& (AccessRightController.getController().getIsPrincipalAuthorized(db, infoGluePrincipal, "Content.Read", contentId.toString()) && AccessRightController.getController().getIsPrincipalAuthorized(db, infoGluePrincipal, "Content.Write", contentId.toString())))
+				{
+					content.getValueObject().getExtraProperties().put("repositoryMarkedForDeletion", content.getRepository().getIsDeleted());
+					contentVOListMarkedForDeletion.add(content.getValueObject());
+				}
+			}
             
 			results.close();
 			oql.close();

--- a/src/java/org/infoglue/cms/controllers/kernel/impl/simple/RepositoryController.java
+++ b/src/java/org/infoglue/cms/controllers/kernel/impl/simple/RepositoryController.java
@@ -739,9 +739,10 @@ public class RepositoryController extends BaseController
 	
 	/**
 	 * Returns a repository list marked for deletion.
+	 * @param infoGluePrincipal 
 	 */
 	
-	public List<RepositoryVO> getRepositoryVOListMarkedForDeletion() throws SystemException, Bug
+	public List<RepositoryVO> getRepositoryVOListMarkedForDeletion(InfoGluePrincipal infoGluePrincipal) throws SystemException, Bug
 	{
 		Database db = CastorDatabaseService.getDatabase();
 		
@@ -757,10 +758,15 @@ public class RepositoryController extends BaseController
 			QueryResults results = oql.execute(Database.READONLY);
 			while (results.hasMore()) 
             {
-                Repository repository = (Repository)results.next();
-                repositoryVOListMarkedForDeletion.add(repository.getValueObject());
-            }
-            
+				Repository repository = (Repository)results.next();
+				Integer repositoryId = repository.getRepositoryId();
+
+				if(AccessRightController.getController().getIsPrincipalAuthorized(db, infoGluePrincipal, "Repository.Read", repositoryId.toString()) && AccessRightController.getController().getIsPrincipalAuthorized(db, infoGluePrincipal, "Repository.Write", repositoryId.toString()))
+				{
+					repositoryVOListMarkedForDeletion.add(repository.getValueObject());
+				}
+			}
+			
 			results.close();
 			oql.close();
 

--- a/src/java/org/infoglue/cms/controllers/kernel/impl/simple/SiteNodeController.java
+++ b/src/java/org/infoglue/cms/controllers/kernel/impl/simple/SiteNodeController.java
@@ -3701,9 +3701,10 @@ public class SiteNodeController extends BaseController
     
 	/**
 	 * Returns a repository list marked for deletion.
+	 * @param infoGluePrincipal 
 	 */
 	
-	public List<SiteNodeVO> getSiteNodeVOListMarkedForDeletion(Integer repositoryId) throws SystemException, Bug
+	public List<SiteNodeVO> getSiteNodeVOListMarkedForDeletion(Integer repositoryId, InfoGluePrincipal infoGluePrincipal) throws SystemException, Bug
 	{
 		Database db = CastorDatabaseService.getDatabase();
 		
@@ -3726,8 +3727,15 @@ public class SiteNodeController extends BaseController
 			while(results.hasMore()) 
             {
 				SiteNode siteNode = (SiteNode)results.next();
-				siteNode.getValueObject().getExtraProperties().put("repositoryMarkedForDeletion", siteNode.getRepository().getIsDeleted());
-                siteNodeVOListMarkedForDeletion.add(siteNode.getValueObject());
+				Integer siteNodeRepositoryId = siteNode.getRepository().getRepositoryId();
+				Integer siteNodeId = siteNode.getSiteNodeId();
+
+				if((AccessRightController.getController().getIsPrincipalAuthorized(db, infoGluePrincipal, "Repository.Read", siteNodeRepositoryId.toString()) && AccessRightController.getController().getIsPrincipalAuthorized(db, infoGluePrincipal, "Repository.Write", siteNodeRepositoryId.toString()))
+					&& (AccessRightController.getController().getIsPrincipalAuthorized(db, infoGluePrincipal, "SiteNodeVersion.Read", siteNodeId.toString()) && AccessRightController.getController().getIsPrincipalAuthorized(db, infoGluePrincipal, "SiteNodeVersion.Write", siteNodeId.toString())))
+				{
+					siteNode.getValueObject().getExtraProperties().put("repositoryMarkedForDeletion", siteNode.getRepository().getIsDeleted());
+					siteNodeVOListMarkedForDeletion.add(siteNode.getValueObject());
+				}
             }
             
 			results.close();


### PR DESCRIPTION
Repository, content and site node lists are now filetered based on the
current users access rights to those objects.

Fix for #93
