### PR TITLE
Adds various impr. to the not. removal of entities

### DIFF
--- a/src/java/org/infoglue/cms/applications/PresentationStrings_en.properties
+++ b/src/java/org/infoglue/cms/applications/PresentationStrings_en.properties
@@ -776,7 +776,6 @@ tool.contenttool.searchResultStateHeader=State
 tool.contenttool.searchResultLastModifiedHeader=Last Modified
 tool.contenttool.searchResultNoMatchesText=No matches found!
 
-tool.contenttool.fixReferencesBeforeDelete.header=There are references to this content that must be deleted first
 tool.contenttool.siteNodeReferences.header=The following pages has references to this content
 tool.contenttool.contentVersionReferences.header=The following contents has references to this content
 tool.contenttool.noContentReferencesFound=There are no contents referencing this content
@@ -863,7 +862,6 @@ tool.structuretool.copyMultiplSiteNodes.finishedText=The copy was successful.
 tool.structuretool.copyMultiplSiteNodes.selectedPagesText=The following pages will be copied
 
 tool.structuretool.pageTemplates.header=Select which page template to use
-tool.structuretool.fixReferencesBeforeDelete.header=There are references to this page that must be deleted first
 tool.structuretool.siteNodeReferences.header=Pages with references
 tool.structuretool.contentVersionReferences.header=Contents with references
 tool.structuretool.noContentReferencesFound=There are no contents referencing this page
@@ -1851,8 +1849,6 @@ tool.common.favouriteComponents.noComponentsTagged=No components tagged as "favo
 tool.contenttool.moveMultiplePages.successText=The pages you choosed to move are now located in the new destination.
 tool.contenttool.moveMultiplePages.failureText=Some items could not be moved as there was constraints prohibiting this.
 
-tool.structuretool.removeAndNotifyAllReferences=Force delete (all contact persons of referencing entities will be notified about the removal)
-tool.structuretool.removeAndCleanAllReferences=Force delete (all referencing entities' references will be cleared)
 tool.structuretool.contactPersonEmail.label=Contact
 tool.structuretool.deleteReferences.referencesFound=References
 entity.ServerNode.property.contactPersonEmailMetaInfoAttribute.label=Meta info attribute for notification email addresses
@@ -2070,3 +2066,14 @@ tool.common.languages.label=Languages
 entity.ServerNode.property.showLanguageVariationsInStructureTree.label=Show language variations in structure tree
 
 entity.ContentTypeDefinition.versionsToKeep.label=Number of versions to keep when archiving / cleaning
+
+tool.structuretool.fixReferencesBeforeDelete.forceDelete.header=There are references to this page that must be deleted first
+tool.structuretool.fixReferencesBeforeDelete.forceDelete.info=Remove referenses from contents and pages using the cross symbol in the lists below. Use <em class="igToolbarAction igFooterToolbarAction">Perform deletion</em> to remove all referenses to this page and delete it.
+tool.structuretool.fixReferencesBeforeDelete.notifiedResponsible.header=The contents and SiteNodes below will be affected by the removal
+tool.structuretool.fixReferencesBeforeDelete.notifiedResponsible.info=Contents and pages in the lists below references this page. When this page is removed the persons responsible for those contents and pages will be notified about the removal. Use <em class="igToolbarAction igFooterToolbarAction">Perform deletion</em> to remove the page.
+tool.structuretool.removeSiteNodeAndReferences=Perform deletion
+
+tool.contenttool.fixReferencesBeforeDelete.forceDelete.header=There are references to this content that must be deleted first
+tool.contenttool.fixReferencesBeforeDelete.forceDelete.info=Remove referenses from contents and pages using the cross symbol in the lists below. Use <em class="igToolbarAction igFooterToolbarAction">Perform deletion</em> to remove all referenses to this page and delete it.
+tool.contenttool.fixReferencesBeforeDelete.notifiedResponsible.header=The contents and SiteNodes below will be affected by the removal
+tool.contenttool.fixReferencesBeforeDelete.notifiedResponsible.info=Contents and pages in the lists below references this content. When this content is removed the persons responsible for those contents and pages will be notified about the removal. Use <em class="igToolbarAction igFooterToolbarAction">Perform deletion</em> to remove the content.

--- a/src/java/org/infoglue/cms/applications/PresentationStrings_fr.properties
+++ b/src/java/org/infoglue/cms/applications/PresentationStrings_fr.properties
@@ -740,7 +740,6 @@ tool.contenttool.searchResultStateHeader=Etat
 tool.contenttool.searchResultLastModifiedHeader=Date de dernière modification
 tool.contenttool.searchResultNoMatchesText=Aucun contenu ne correspond aux critères !
 
-tool.contenttool.fixReferencesBeforeDelete.header=Il y a des références à ce contenu qui doivent être supprimées en premier
 tool.contenttool.siteNodeReferences.header=Les pages suivantes ont des références à ce contenu
 tool.contenttool.contentVersionReferences.header=Les contenus suivants ont des références avec ce contenu
 tool.contenttool.noContentReferencesFound=Il n'y a pas de contenu qui a des références avec ce contenu
@@ -827,7 +826,6 @@ tool.structuretool.copyMultiplSiteNodes.finishedText=The copy was successful.
 tool.structuretool.copyMultiplSiteNodes.selectedPagesText=The following pages will be copied
 
 tool.structuretool.pageTemplates.header=Sélectionner quel template utiliser
-tool.structuretool.fixReferencesBeforeDelete.header=Il y a des références à cette page qui doivent être supprimées en premier
 tool.structuretool.siteNodeReferences.header=Les pages suivantes ont des références avec cette page
 tool.structuretool.contentVersionReferences.header=Les contenus suivants ont des références avec cette page
 tool.structuretool.noContentReferencesFound=Il n'y a pas de contenus avec des références à cette page
@@ -1820,9 +1818,6 @@ tool.common.favouriteComponents.noComponentsTagged=No components tagged as "favo
 tool.contenttool.moveMultiplePages.successText=The pages you choosed to move are now located in the new destination.
 tool.contenttool.moveMultiplePages.failureText=Some items could not be moved as there was constraints prohibiting this.
 
-
-tool.structuretool.removeAndNotifyAllReferences=Force delete (all contact persons of referencing entities will be notified about the removal)
-tool.structuretool.removeAndCleanAllReferences=Force delete (all referencing entities' references will be cleared)
 tool.structuretool.contactPersonEmail.label=Contact
 tool.structuretool.deleteReferences.referencesFound=References
 entity.ServerNode.property.contactPersonEmailMetaInfoAttribute.label=Meta info attribute for notification email addresses
@@ -2040,3 +2035,14 @@ tool.common.languages.label=Languages
 entity.ServerNode.property.showLanguageVariationsInStructureTree.label=Show language variations in structure tree
 
 entity.ContentTypeDefinition.versionsToKeep.label=Number of versions to keep when archiving / cleaning
+
+tool.structuretool.fixReferencesBeforeDelete.forceDelete.header=Il y a des références à cette page qui doivent être supprimées en premier
+tool.structuretool.fixReferencesBeforeDelete.forceDelete.info=Remove referenses from content and pages using the cross symbol in the lists below. Use <em class="igToolbarAction igFooterToolbarAction">Perform deletion</em> to remove all referenses to this page and delete the page.
+tool.structuretool.fixReferencesBeforeDelete.notifiedResponsible.header=The contents and SiteNodes below will be affected by the removal
+tool.structuretool.fixReferencesBeforeDelete.notifiedResponsible.info=Contents and pages in the list below references this page. When this page is removed the persons responsible for those contents and pages will be notified about the removal. Use <em class="igToolbarAction igFooterToolbarAction">Perform deletion</em> to remove the page.
+tool.structuretool.removeSiteNodeAndReferences=Perform deletion
+
+tool.contenttool.fixReferencesBeforeDelete.forceDelete.header=Il y a des références à ce contenu qui doivent être supprimées en premier
+tool.contenttool.fixReferencesBeforeDelete.forceDelete.info=Remove referenses from contents and pages using the cross symbol in the lists below. Use <em class="igToolbarAction igFooterToolbarAction">Perform deletion</em> to remove all referenses to this page and delete it.
+tool.contenttool.fixReferencesBeforeDelete.notifiedResponsible.header=The contents and SiteNodes below will be affected by the removal
+tool.contenttool.fixReferencesBeforeDelete.notifiedResponsible.info=Contents and pages in the list below references this content. When this content is removed the persons responsible for those contents and pages will be notified about the removal. Use <em class="igToolbarAction igFooterToolbarAction">Perform deletion</em> to remove the content.

--- a/src/java/org/infoglue/cms/applications/PresentationStrings_sv.properties
+++ b/src/java/org/infoglue/cms/applications/PresentationStrings_sv.properties
@@ -741,7 +741,6 @@ tool.contenttool.searchResultStateHeader=Status
 tool.contenttool.searchResultLastModifiedHeader=Senast ändrad
 tool.contenttool.searchResultNoMatchesText=Inga innehåll matchade sökningen!
 
-tool.contenttool.fixReferencesBeforeDelete.header=Det finns referenser till detta innehåll som du måste åtgärda först
 tool.contenttool.siteNodeReferences.header=På följande sidor finns referenser till detta innehåll
 tool.contenttool.contentVersionReferences.header=I följande innehåll finns referenser till detta innehåll
 tool.contenttool.noContentReferencesFound=Det finns inga innehåll som refererar till detta innehåll
@@ -828,7 +827,6 @@ tool.structuretool.copyMultiplSiteNodes.finishedText=Kopieringen lyckades
 tool.structuretool.copyMultiplSiteNodes.selectedPagesText=Följande sidor kommer att kopieras
 
 tool.structuretool.pageTemplates.header=Ange vilken sidmall som skall användas
-tool.structuretool.fixReferencesBeforeDelete.header=Det finns referenser till denna sida som du måste åtgärda först
 tool.structuretool.siteNodeReferences.header=Sidor med referenser
 tool.structuretool.contentVersionReferences.header=Innehåll med referenser
 tool.structuretool.noContentReferencesFound=Det finns inga innehåll som refererar till denna sida
@@ -1816,8 +1814,6 @@ tool.common.loading.label=Laddar...
 tool.common.favouriteComponents.noComponentsTagged=Komponenter som skall visas här taggas av ansvarig utvecklare.
 tool.contenttool.moveMultiplePages.successText=Sidorna befinner sig nu på sin nya plats.
 tool.contenttool.moveMultiplePages.failureText=Några sidor kunde inte flyttas pga restriktioner eller fel.
-tool.structuretool.removeAndNotifyAllReferences=Tvinga borttagning (alla kontaktpersoner för refererande entiteter kommer att notifieras om borttagningen)
-tool.structuretool.removeAndCleanAllReferences=Tvinga borttagning (alla referenser i de refererande entiteterna kommer att raderas)
 tool.structuretool.contactPersonEmail.label=Kontaktperson
 tool.structuretool.deleteReferences.referencesFound=Referenser
 entity.ServerNode.property.contactPersonEmailMetaInfoAttribute.label=Meta info-attribut för notifikations e-postadresser
@@ -2038,3 +2034,15 @@ tool.common.languages.label=Språk
 entity.ServerNode.property.showLanguageVariationsInStructureTree.label=Visa språkvariationer i struktur-trädet
 
 entity.ContentTypeDefinition.versionsToKeep.label=Antal versioner som skall sparas vid arkivering
+
+tool.structuretool.fixReferencesBeforeDelete.forceDelete.header=Det finns referenser till denna sida som du måste åtgärda först
+tool.structuretool.fixReferencesBeforeDelete.forceDelete.info=Ta bort referenser från innehåll och sidor med hjälp av kryssen till vänster i listorna nedan. Använd <em class="igToolbarAction igFooterToolbarAction">Genomför borttag</em> för att ta bort alla referenser till denna sida och ta bort sidan.
+tool.structuretool.fixReferencesBeforeDelete.notifiedResponsible.header=Följande sidor och innehåll kommer påverkas
+tool.structuretool.fixReferencesBeforeDelete.notifiedResponsible.info=Sidor och innehåll i listorna nedan refererar denna sida. När denna sida tas bort kommer de ansvariga för sidorna och innehållen bli notifierade om att sidan tagits bort. Använd <em class="igToolbarAction igFooterToolbarAction">Genomför borttag</em> för att ta bort sidan.
+# This label is used in the contenttool as well
+tool.structuretool.removeSiteNodeAndReferences=Genomför borttag
+
+tool.contenttool.fixReferencesBeforeDelete.forceDelete.header=Det finns referenser till detta innehåll som du måste åtgärda först
+tool.contenttool.fixReferencesBeforeDelete.forceDelete.info=Ta bort referenser från innehåll och sidor med hjälp av kryssen till vänster i listorna nedan. Använd <em class="igToolbarAction igFooterToolbarAction">Genomför borttag</em> för att ta bort alla referenser till detta innehåll och ta bort innehållet.
+tool.contenttool.fixReferencesBeforeDelete.notifiedResponsible.header=Följande sidor och innehåll kommer påverkas
+tool.contenttool.fixReferencesBeforeDelete.notifiedResponsible.info=Sidor och innehåll i listorna nedan refererar detta innehåll. När detta innehåll tas bort kommer de ansvariga för sidorna och innehållen bli notifierade om att innehållet tagits bort. Använd <em class="igToolbarAction igFooterToolbarAction">Genomför borttag</em> för att ta bort innehållet.

--- a/src/java/org/infoglue/cms/applications/contenttool/actions/DeleteContentAction.java
+++ b/src/java/org/infoglue/cms/applications/contenttool/actions/DeleteContentAction.java
@@ -37,6 +37,7 @@ import org.infoglue.cms.entities.content.ContentVO;
 import org.infoglue.cms.entities.management.RegistryVO;
 import org.infoglue.cms.exception.ConstraintException;
 import org.infoglue.cms.exception.SystemException;
+import org.infoglue.cms.util.CmsPropertyHandler;
 
 /**
  * This action removes a content from the system.
@@ -331,6 +332,11 @@ public class DeleteContentAction extends InfoGlueAbstractAction
 	public String getOriginalAddress()
 	{
 		return this.originalAddress;
+	}
+
+	public boolean getNotifyResponsibleOnReferenceChange()
+	{
+		return CmsPropertyHandler.getNotifyResponsibleOnReferenceChange();
 	}
 
 	public String getReturnAddress()

--- a/src/java/org/infoglue/cms/applications/structuretool/actions/DeleteSiteNodeAction.java
+++ b/src/java/org/infoglue/cms/applications/structuretool/actions/DeleteSiteNodeAction.java
@@ -277,6 +277,11 @@ public class DeleteSiteNodeAction extends InfoGlueAbstractAction
 		this.returnAddress = returnAddress;
 	}
 
+	public boolean getNotifyResponsibleOnReferenceChange()
+	{
+		return CmsPropertyHandler.getNotifyResponsibleOnReferenceChange();
+	}
+
 	public String getReturnAddress()
 	{
 		if(this.returnAddress != null && !this.returnAddress.equals(""))

--- a/src/java/org/infoglue/cms/controllers/kernel/impl/simple/ContentController.java
+++ b/src/java/org/infoglue/cms/controllers/kernel/impl/simple/ContentController.java
@@ -3922,12 +3922,14 @@ public class ContentController extends BaseController
 							}
 							else
 							{
+								LanguageVO languageVO;
 								for(ReferenceVersionBean versionBean : reference.getVersions())
 								{
 									ContentVersionVO version = (ContentVersionVO)versionBean.getReferencingObject();
 									languageId = version.getLanguageId();
+									languageVO = LanguageController.getController().getLanguageVOWithId(languageId, db);
 									url = CmsPropertyHandler.getCmsFullBaseUrl() + "/Admin.action?contentId=" + ((ContentVO)reference.getReferencingCompletingObject()).getContentId() + "&languageId=" + languageId;
-									contentBuilder.append("<li><a href=\"" + url + "\">" + path + "</a> (" + version.getLanguageName() + ")</li>");
+									contentBuilder.append("<li><a href=\"" + url + "\">" + path + "</a>" + (languageVO == null ? "" : " (" + languageVO.getLocalizedDisplayLanguage() + ")") + "</li>");
 								}
 							}
 						}

--- a/src/java/org/infoglue/cms/controllers/kernel/impl/simple/ToolbarController.java
+++ b/src/java/org/infoglue/cms/controllers/kernel/impl/simple/ToolbarController.java
@@ -3946,11 +3946,7 @@ public class ToolbarController implements ToolbarProvider
 	{
 		List<ToolbarButton> buttons = new ArrayList<ToolbarButton>();
 
-		String label = "tool.structuretool.removeAndCleanAllReferences";
-		if (CmsPropertyHandler.getNotifyResponsibleOnReferenceChange())
-		{
-			label = "tool.structuretool.removeAndNotifyAllReferences";
-		}
+		String label = "tool.structuretool.removeSiteNodeAndReferences";
 
 		buttons.add(new ToolbarButton("",
 				getLocalizedString(locale, label),
@@ -3968,11 +3964,7 @@ public class ToolbarController implements ToolbarProvider
 	{
 		List<ToolbarButton> buttons = new ArrayList<ToolbarButton>();
 
-		String label = "tool.structuretool.removeAndCleanAllReferences";
-		if (CmsPropertyHandler.getNotifyResponsibleOnReferenceChange())
-		{
-			label = "tool.structuretool.removeAndNotifyAllReferences";
-		}
+		String label = "tool.structuretool.removeSiteNodeAndReferences";
 
 		buttons.add(new ToolbarButton("",
 				getLocalizedString(locale, label),

--- a/src/webapp/cms/contenttool/showRelations.vm
+++ b/src/webapp/cms/contenttool/showRelations.vm
@@ -76,7 +76,21 @@
 
 <div style="clear: both;"></div>
 
-<h3>$ui.getString("tool.contenttool.fixReferencesBeforeDelete.header")</h3>
+<h3>
+#if($notifyResponsibleOnReferenceChange)
+$ui.getString("tool.contenttool.fixReferencesBeforeDelete.notifiedResponsible.header")
+#else
+$ui.getString("tool.contenttool.fixReferencesBeforeDelete.forceDelete.header")
+#end
+</h3>
+
+<p>
+#if($notifyResponsibleOnReferenceChange)
+	$ui.getString("tool.contenttool.fixReferencesBeforeDelete.notifiedResponsible.info")
+#else
+	$ui.getString("tool.contenttool.fixReferencesBeforeDelete.forceDelete.info")
+#end
+</p>
 
 <div id="tabsContainer" class="flora cleanTopDiv">
 	<ul>
@@ -89,7 +103,9 @@
 		<table cellpadding="0" cellspacing="0" border="1" class="display" id="contentVersions" width="100%">
 			<thead>
 				<tr>
+					#if(!$notifyResponsibleOnReferenceChange)
 					<th>$ui.getString("tool.common.action.label")</th>
+					#end
 					<th>$ui.getString("tool.contenttool.searchResultContentHeader")</th>
 					<th>$ui.getString("tool.structuretool.contactPersonEmail.label")</th>
 				</tr>
@@ -102,10 +118,13 @@
 						#set($lastIndex = $referenceBean.versions.size() - 1)
 			
 						#foreach ($version in $referenceBean.versions)
+						#set( $currentLanguageName = $this.getLanguageVO($version.referencingObject.languageId) )
 						<tr>
-							<td><a class="deleteCross" href="DeleteContent!deleteReference.action?siteNodeId=$originalSiteNodeId#foreach($version in $referenceBean.versions)#foreach($registryVO in $version.registryVOList)&registryId=$registryVO.id#end#end&returnAddress=$returnAddress&userSessionKey=$userSessionKey">&nbsp;</a></td>
+							#if(!$notifyResponsibleOnReferenceChange)
+							<td><a class="deleteCross" href="DeleteContent!deleteReference.action?contentId=$originalContentId#foreach($registryVO in $version.registryVOList)&registryId=$registryVO.id#end&returnAddress=$returnAddress&userSessionKey=$userSessionKey">&nbsp;</a></td>
+							#end
 							<td>
-								<a href="ViewContentVersion!standalone.action?contentId=$referenceBean.referencingCompletingObject.contentId&languageId=$version.referencingObject.languageId" target="_blank">$referenceBean.path</a> ($version.referencingObject.languageName)
+								<a href="ViewContentVersion!standalone.action?contentId=$referenceBean.referencingCompletingObject.contentId&languageId=$version.referencingObject.languageId" target="_blank">$referenceBean.path</a> ($currentLanguageName)
 			 				</td>
 			 				<td>
 								$referenceBean.contactPersonEmail
@@ -117,7 +136,9 @@
 
 				#if(!$hasContentReferences)
 					<tr>
+						#if(!$notifyResponsibleOnReferenceChange)
 						<td>&nbsp;</td>
+						#end
 						<td>$ui.getString("tool.structuretool.noContentReferencesFound")</td>
 						<td>&nbsp;</td>
 					</tr>
@@ -126,14 +147,15 @@
 			</tbody>
 		</table>
 		
-    </div>
+	</div>
 
-    <div id="pageReferencesTab" class="inlineTabDiv">
-    
+	<div id="pageReferencesTab" class="inlineTabDiv">
 		<table cellpadding="0" cellspacing="0" border="1" class="display" id="siteNodes" width="100%">
 			<thead>
 				<tr>
+					#if(!$notifyResponsibleOnReferenceChange)
 					<th>$ui.getString("tool.common.action.label")</th>
+					#end
 					<th>$ui.getString("tool.contenttool.searchResultPageHeader")</th>
 					<th>$ui.getString("tool.structuretool.contactPersonEmail.label")</th>
 				</tr>
@@ -145,7 +167,9 @@
 						#set($hasPageReferences = true)
 						#set($lastIndex = $referenceBean.versions.size() - 1)
 						<tr>
-							<td><a class="deleteCross" href="DeleteContent!deleteReference.action?siteNodeId=$originalSiteNodeId#foreach($version in $referenceBean.versions)#foreach($registryVO in $version.registryVOList)&registryId=$registryVO.id#end#end&returnAddress=$returnAddress&userSessionKey=$userSessionKey">&nbsp;</a></td>
+							#if(!$notifyResponsibleOnReferenceChange)
+							<td><a class="deleteCross" href="DeleteContent!deleteReference.action?contentId=$originalContentId#foreach($version in $referenceBean.versions)#foreach($registryVO in $version.registryVOList)&registryId=$registryVO.id#end#end&returnAddress=$returnAddress&userSessionKey=$userSessionKey">&nbsp;</a></td>
+							#end
 							<td>
 								<a href="DeleteContent!fixPage.action?siteNodeId=$referenceBean.referencingCompletingObject.siteNodeId&contentId=-1&returnAddress=$returnAddress" target="_blank">$referenceBean.path</a>
 			 				</td>
@@ -158,7 +182,9 @@
 
 				#if(!$hasPageReferences)
 					<tr>
+						#if(!$notifyResponsibleOnReferenceChange)
 						<td>&nbsp;</td>
+						#end
 						<td>$ui.getString("tool.contenttool.noPageReferencesFound")</td>
 						<td>&nbsp;</td>
 					</tr>
@@ -166,7 +192,7 @@
 
 			</tbody>
 		</table>
-    </div>
+	</div>
 </div>
 
 #lightFooterToolbar($footerButtons)

--- a/src/webapp/cms/structuretool/showRelations.vm
+++ b/src/webapp/cms/structuretool/showRelations.vm
@@ -74,19 +74,36 @@
 
 <div style="clear: both;"></div>
 
-<h3>$ui.getString("tool.structuretool.fixReferencesBeforeDelete.header")</h3>
+<h3>
+#if($notifyResponsibleOnReferenceChange)
+$ui.getString("tool.structuretool.fixReferencesBeforeDelete.notifiedResponsible.header")
+#else
+$ui.getString("tool.structuretool.fixReferencesBeforeDelete.forceDelete.header")
+#end
+</h3>
+
+<p>
+#if($notifyResponsibleOnReferenceChange)
+	$ui.getString("tool.structuretool.fixReferencesBeforeDelete.notifiedResponsible.info")
+#else
+	$ui.getString("tool.structuretool.fixReferencesBeforeDelete.forceDelete.info")
+#end
+</p>
 
 <div id="tabsContainer" class="flora cleanTopDiv">
 	<ul>
-        <li><a href="#contentReferencesTab"><span>$ui.getString("tool.structuretool.contentVersionReferences.header")</span></a></li>
-        <li><a href="#pageReferencesTab"><span>$ui.getString("tool.structuretool.siteNodeReferences.header")</span></a></li>
-    </ul>
+		<li><a href="#contentReferencesTab"><span>$ui.getString("tool.structuretool.contentVersionReferences.header")</span></a></li>
+		<li><a href="#pageReferencesTab"><span>$ui.getString("tool.structuretool.siteNodeReferences.header")</span></a></li>
+	</ul>
 
-    <div id="contentReferencesTab" class="inlineTabDiv">
+	<div id="contentReferencesTab" class="inlineTabDiv">
+
 		<table cellpadding="0" cellspacing="0" border="1" class="display" id="contentVersions" width="100%">
 			<thead>
 				<tr>
+					#if(!$notifyResponsibleOnReferenceChange)
 					<th>$ui.getString("tool.common.action.label")</th>
+					#end
 					<th>$ui.getString("tool.contenttool.searchResultContentHeader")</th>
 					<th>$ui.getString("tool.structuretool.contactPersonEmail.label")</th>
 				</tr>
@@ -97,10 +114,12 @@
 					#if($referenceBean.referencingCompletingObject.class.name.indexOf("Content") > -1)
 						#set($hasContentReferences = true)
 						#set($lastIndex = $referenceBean.versions.size() - 1)
-			
+
 						#foreach ($version in $referenceBean.versions)
 						<tr>
+							#if(!$notifyResponsibleOnReferenceChange)
 							<td><a class="deleteCross" href="DeleteSiteNode!deleteReference.action?siteNodeId=$originalSiteNodeId#foreach($version in $referenceBean.versions)#foreach($registryVO in $version.registryVOList)&registryId=$registryVO.id#end#end&returnAddress=$returnAddress&userSessionKey=$userSessionKey">&nbsp;</a></td>
+							#end
 							<td>
 								<a href="ViewContentVersion!standalone.action?contentId=$referenceBean.referencingCompletingObject.contentId&languageId=$version.referencingObject.languageId" target="_blank">$referenceBean.path</a> ($version.referencingObject.languageName)
 			 				</td>
@@ -114,7 +133,9 @@
 
 				#if(!$hasContentReferences)
 					<tr>
+						#if(!$notifyResponsibleOnReferenceChange)
 						<td>&nbsp;</td>
+						#end
 						<td>$ui.getString("tool.structuretool.noContentReferencesFound")</td>
 						<td>&nbsp;</td>
 					</tr>
@@ -122,13 +143,15 @@
 
 			</tbody>
 		</table>
-    </div>
+	</div>
 
-    <div id="pageReferencesTab" class="inlineTabDiv">
+	<div id="pageReferencesTab" class="inlineTabDiv">
 		<table cellpadding="0" cellspacing="0" border="1" class="display" id="siteNodes" width="100%">
 			<thead>
 				<tr>
+					#if(!$notifyResponsibleOnReferenceChange)
 					<th>$ui.getString("tool.common.action.label")</th>
+					#end
 					<th>$ui.getString("tool.contenttool.searchResultPageHeader")</th>
 					<th>$ui.getString("tool.structuretool.contactPersonEmail.label")</th>
 				</tr>
@@ -140,7 +163,9 @@
 						#set($hasPageReferences = true)
 						#set($lastIndex = $referenceBean.versions.size() - 1)
 						<tr>
+							#if(!$notifyResponsibleOnReferenceChange)
 							<td><a class="deleteCross" href="DeleteSiteNode!deleteReference.action?siteNodeId=$originalSiteNodeId#foreach($version in $referenceBean.versions)#foreach($registryVO in $version.registryVOList)&registryId=$registryVO.id#end#end&returnAddress=$returnAddress&userSessionKey=$userSessionKey">&nbsp;</a></td>
+							#end
 							<td>
 								<a href="DeleteContent!fixPage.action?siteNodeId=$referenceBean.referencingCompletingObject.siteNodeId&contentId=-1&returnAddress=$returnAddress" target="_blank">$referenceBean.path</a>
 			 				</td>
@@ -153,7 +178,9 @@
 
 				#if(!$hasPageReferences)
 					<tr>
+						#if(!$notifyResponsibleOnReferenceChange)
 						<td>&nbsp;</td>
+						#end
 						<td>$ui.getString("tool.contenttool.noPageReferencesFound")</td>
 						<td>&nbsp;</td>
 					</tr>
@@ -161,7 +188,7 @@
 
 			</tbody>
 		</table>
-    </div>
+	</div>
 </div>
 
 #lightFooterToolbar($footerButtons)


### PR DESCRIPTION
- Fixes a problem where the ContentVersion's language name was not
  displayed for Content->Content references
- Fixed a problem where all references from a Content was cleared when
  the user tried to only clear one (red cross symbol)
- Changes the name of the force delete button in the reference views and
  adds an explanatory text instead so the user understand the effects of
  executing the action
