### PR TITLE
Fixes a problem with ContentVersion tooltips

### DIFF
--- a/src/webapp/cms/managementtool/macro.vm
+++ b/src/webapp/cms/managementtool/macro.vm
@@ -3323,7 +3323,7 @@ $ui.getString("entity.${fieldNameKey}.label")
 					-->
 					</script>
 				#elseif($attribute.inputType == "textfield")
-                    <label for="$attribute.name" title="$attribute.name"><span class="attributeTitle">$attributeTitle</span> #if($attributeDescription.trim() != "")<div class="fieldHelp" title="$attributeDescription"></div>#end
+                    <label for="$attribute.name" title="$attribute.name"><span class="attributeTitle">$attributeTitle</span> #if($attributeDescription.trim() != "")<div class="fieldHelp" title=" " data-ig-tooltip="$attributeDescription"></div>#end
 					#printErrorV3("ContentVersion.$attribute.name" false)</label>
 					<input $readonly type="text" length="50" class="$class" maxlength="" id="$attribute.name" name="$attribute.name" value="$value"/>
 				#elseif($attribute.inputType == "textarea")
@@ -3331,7 +3331,7 @@ $ui.getString("entity.${fieldNameKey}.label")
 					<table cellpadding="0" cellspacing="0" border="0" width="100%">
 					    <tr>
 					    	<td align="left">
-                                <label for="$attribute.name" title="$attribute.name"><span class="attributeTitle">$attributeTitle</span> #if($attributeDescription.trim() != "")<div class="fieldHelp" title="$attributeDescription"></div>#end
+                                <label for="$attribute.name" title="$attribute.name"><span class="attributeTitle">$attributeTitle</span> #if($attributeDescription.trim() != "")<div class="fieldHelp" title=" " data-ig-tooltip="$attributeDescription"></div>#end
 								#printErrorV3("ContentVersion.$attribute.name" false)</label>
 							</td>
 					    	<td align="right">
@@ -3631,7 +3631,7 @@ $ui.getString("entity.${fieldNameKey}.label")
 						
 				#elseif($attribute.inputType == "select")
 					<!-- Handles the input type select = dropbox -->
-                    <label for="$attribute.name" title="$attribute.name"><span class="attributeTitle">$attributeTitle</span> #if($attributeDescription.trim() != "")<div class="fieldHelp" title="$attributeDescription"></div>#end
+                    <label for="$attribute.name" title="$attribute.name"><span class="attributeTitle">$attributeTitle</span> #if($attributeDescription.trim() != "")<div class="fieldHelp" title=" " data-ig-tooltip="$attributeDescription"></div>#end
 					#printErrorV3("ContentVersion.$attribute.name" false)</label>
 					<select $readonly size="1" id="$attribute.name" name="$attribute.name" class="$class">
 						#foreach($option in $attribute.options)
@@ -3640,7 +3640,7 @@ $ui.getString("entity.${fieldNameKey}.label")
 		    		</select>
 				#elseif($attribute.inputType == "checkbox")
 					<!-- Handles the input type checkbox -->
-					<label for="$attribute.name" title="$attribute.name"><span class="attributeTitle">$attributeTitle</span> #if($attributeDescription.trim() != "")<div class="fieldHelp" title="$attributeDescription"></div>#end
+					<label for="$attribute.name" title="$attribute.name"><span class="attributeTitle">$attributeTitle</span> #if($attributeDescription.trim() != "")<div class="fieldHelp" title=" " data-ig-tooltip="$attributeDescription"></div>#end
 			    	#printErrorV3("ContentVersion.$attribute.name" false)
 					#if($widget == "transfer")
 		
@@ -3688,7 +3688,7 @@ $ui.getString("entity.${fieldNameKey}.label")
 
 				#elseif($attribute.inputType == "radiobutton")
 				<!-- Handles the input type radiobutton -->
-					<label for="$attribute.name" title="$attribute.name"><span class="attributeTitle">$attributeTitle</span> #if($attributeDescription.trim() != "")<div class="fieldHelp" title="$attributeDescription"></div>#end
+					<label for="$attribute.name" title="$attribute.name"><span class="attributeTitle">$attributeTitle</span> #if($attributeDescription.trim() != "")<div class="fieldHelp" title=" " data-ig-tooltip="$attributeDescription"></div>#end
 					#printErrorV3("ContentVersion.$attribute.name" false)</label>
 					<ul class="optionList">
 					#foreach($option in $attribute.options)
@@ -3698,7 +3698,7 @@ $ui.getString("entity.${fieldNameKey}.label")
 				#elseif($attribute.inputType == "customfield")
 				<!-- Handles the input type customfield -->
 					#set($attributeMarkup = $!attribute.getContentTypeAttribute("Markup").getContentTypeAttributeParameterValue().getValue("label"))
-                    <label for="$attribute.name" title="$attribute.name"><span class="attributeTitle">$attributeTitle</span> #if($attributeDescription.trim() != "")<div class="fieldHelp" title="$attributeDescription"></div>#end
+                    <label for="$attribute.name" title="$attribute.name"><span class="attributeTitle">$attributeTitle</span> #if($attributeDescription.trim() != "")<div class="fieldHelp" title=" " data-ig-tooltip="$attributeDescription"></div>#end
 					#printErrorV3("ContentVersion.$attribute.name" false)</label>
 					#set($processedMarkup = $attributeMarkup.replaceAll("attributeName", "$attribute.name"))
 					#set($processedMarkup = $processedMarkup.replaceAll("attributeValue", "$value"))

--- a/src/webapp/cms/structuretool/v3/createSiteNode.vm
+++ b/src/webapp/cms/structuretool/v3/createSiteNode.vm
@@ -98,7 +98,7 @@
 									#if(($attribute.name == "Title" || $attribute.name == "NavigationTitle" || $attribute.name == "NavigationTitle" || $attribute.name == "NiceURIName") && $languageVO.languageId == $languageId)
 										#set($autofill = true)
 									#end
-									<p><span class="attributeTitle">$attributeTitle</span> #if($attributeDescription.trim() != "")<span class="fieldHelp" title="$attributeDescription"></span>#end<br/>
+									<p><span class="attributeTitle">$attributeTitle</span> #if($attributeDescription.trim() != "")<span class="fieldHelp" data-ig-tooltip="$attributeDescription"></span>#end<br/>
 									<input type="text" id="${languageVO.languageCode}_$attribute.name" name="${languageVO.languageCode}_$attribute.name" value="" class="normaltextfield #if($autofill)autofill#end"/></p>
 								#end
 							</div>

--- a/src/webapp/css/infoglue.css
+++ b/src/webapp/css/infoglue.css
@@ -684,7 +684,7 @@ label {
 	border-radius: 5px;
 	top: 0px;
 	color: #fff;
-	content: attr(title);
+	content: attr(data-ig-tooltip);
 	left: 26px;
 	margin-top: -4px;
 	padding: 5px 15px;


### PR DESCRIPTION
The native title attribute tooltip was displayed along side the Infoglue
specific tooltip. This commit changes the attribute used for the Infoglue
tooltip so that we do not clash with native attributes.
