### PR TITLE
Added access control to the structure tool and content tool tree views.

### DIFF
--- a/src/java/org/infoglue/cms/applications/contenttool/actions/ViewContentToolMenuHtmlAction.java
+++ b/src/java/org/infoglue/cms/applications/contenttool/actions/ViewContentToolMenuHtmlAction.java
@@ -28,8 +28,6 @@ import java.util.List;
 
 import org.apache.log4j.Logger;
 import org.infoglue.cms.applications.common.actions.TreeViewAbstractAction;
-import org.infoglue.cms.controllers.kernel.impl.simple.AccessRightController;
-import org.infoglue.cms.controllers.kernel.impl.simple.CastorDatabaseService;
 import org.infoglue.cms.controllers.kernel.impl.simple.ContentTypeDefinitionController;
 import org.infoglue.cms.controllers.kernel.impl.simple.RepositoryController;
 import org.infoglue.cms.controllers.kernel.impl.simple.RepositoryLanguageController;
@@ -104,20 +102,15 @@ public class ViewContentToolMenuHtmlAction extends TreeViewAbstractAction
 	 */
 	protected INodeSupplier getNodeSupplier() throws Exception, org.infoglue.cms.exception.SystemException
 	{
+		String interceptionPointName = isBinding() ? "Repository.ReadForBinding" : "Repository.Read";
+		
 		if (getRepositoryId() == null  || getRepositoryId().intValue() < 1)
 		{
 			return null;
 		}
-		
+
 		// Check if this user really has access to this repository
-		String interceptionPointName = isBinding() ? "Repository.ReadForBinding" : "Repository.Read";
-		AccessRightController accessController = AccessRightController.getController();
-		boolean hasAccess = accessController.getIsPrincipalAuthorized(CastorDatabaseService.getDatabase(), 
-		                                                              getInfoGluePrincipal(), 
-		                                                              interceptionPointName, 
-		                                                              getRepositoryId().toString());
-		
-		if (hasAccess)
+		if (hasAccessTo(interceptionPointName, getRepositoryId().toString()))
 		{
 			if (this.showVersions == null || this.showVersions.equals("")) 
 			{

--- a/src/java/org/infoglue/cms/applications/structuretool/actions/ViewStructureToolMenuHtmlAction.java
+++ b/src/java/org/infoglue/cms/applications/structuretool/actions/ViewStructureToolMenuHtmlAction.java
@@ -25,10 +25,6 @@ package org.infoglue.cms.applications.structuretool.actions;
 
 import org.apache.log4j.Logger;
 import org.infoglue.cms.applications.common.actions.TreeViewAbstractAction;
-import org.infoglue.cms.applications.contenttool.actions.CreateContentAction;
-import org.infoglue.cms.controllers.kernel.impl.simple.AccessRightController;
-import org.infoglue.cms.controllers.kernel.impl.simple.CastorDatabaseService;
-import org.infoglue.cms.controllers.kernel.impl.simple.RepositoryController;
 import org.infoglue.cms.exception.SystemException;
 import org.infoglue.cms.treeservice.ss.SiteNodeNodeSupplier;
 import org.infoglue.cms.util.CmsPropertyHandler;
@@ -89,18 +85,16 @@ public class ViewStructureToolMenuHtmlAction extends TreeViewAbstractAction
 	 */
 	protected INodeSupplier getNodeSupplier() throws Exception, SystemException
 	{
-		if(getRepositoryId() == null  || getRepositoryId().intValue() < 1)
+		String interceptionPointName = isBinding() ? "Repository.ReadForBinding" : "Repository.Read";
+
+		if(getRepositoryId() == null  || getRepositoryId().intValue() < 1) 
+		{
 			this.repositoryId = super.getRepositoryId();
+		}
 
 		// Check if this user really has access to this repository
-		String interceptionPointName = isBinding() ? "Repository.ReadForBinding" : "Repository.Read";
-		AccessRightController accessController = AccessRightController.getController();
-		boolean hasAccess = accessController.getIsPrincipalAuthorized(CastorDatabaseService.getDatabase(), 
-		                                                              getInfoGluePrincipal(), 
-		                                                              interceptionPointName, 
-		                                                              getRepositoryId().toString());
-
-		if (hasAccess) {
+		if (hasAccessTo(interceptionPointName, getRepositoryId().toString()))
+		{
 			String treeMode = CmsPropertyHandler.getTreeMode(); 
 			if(treeMode != null) {
 				setTreeMode(treeMode);
@@ -108,7 +102,9 @@ public class ViewStructureToolMenuHtmlAction extends TreeViewAbstractAction
 			SiteNodeNodeSupplier sup = new SiteNodeNodeSupplier(getRepositoryId(), this.getInfoGluePrincipal(), sortLanguageId);
 			rootNode = sup.getRootNode();
 			return sup;
-		} else {
+		}
+		else
+		{
 			return null;
 		}
 	}


### PR DESCRIPTION
By following a link to a page in another repository, or just going directly to http://host/infoglueCMS/ViewContentHtmlTree.action?repositoryId=...&sortLanguageId=... it was possible to view the structure even if the user doesn't have access to that repository. Also true for corresponding content tree.
