### PR TITLE
Move assets now reloads the content view on success

### DIFF
--- a/src/java/org/infoglue/cms/applications/contenttool/actions/MoveDigitalAssetAction.java
+++ b/src/java/org/infoglue/cms/applications/contenttool/actions/MoveDigitalAssetAction.java
@@ -142,8 +142,7 @@ public class MoveDigitalAssetAction extends InfoGlueAbstractAction
 		{
 			ceb.throwIfNotEmpty();
 			ContentControllerProxy.getController().acMoveDigitalAsset(this.getInfoGluePrincipal(), this.getDigitalAssetId(), this.getContentId(), this.fixReferences);
-			String successAction = "(parent.refreshView || parent.parent.refreshView)('contentVersionAssets');";
-			successAction += "closeDialog();";
+			String successAction = "(\"refreshAll\" in parent ? parent.refreshAll() : parent.location.reload());";
 			addActionLinkFirst(userSessionKey, new LinkBean("parent.parent.refreshView('contentVersionAssets');", "", "", "", successAction, true, ""));
 			setActionExtraData(userSessionKey, "confirmationMessage", getLocalizedString(getLocale(), "tool.contenttool.assetMoved.confirmation", getContentVO(this.getContentId()).getName()));
 		}


### PR DESCRIPTION
Before when an asset was moved it was possible to break the content's
reference by saving the content after the move operation was completed due
to the fact that the content version view was not reloaded.
