### PR TITLE
Pages and contents w/o names now print ID

### DIFF
--- a/src/java/org/infoglue/cms/applications/common/actions/SearchAction.java
+++ b/src/java/org/infoglue/cms/applications/common/actions/SearchAction.java
@@ -38,6 +38,7 @@ import org.infoglue.cms.controllers.kernel.impl.simple.LanguageController;
 import org.infoglue.cms.controllers.kernel.impl.simple.LuceneController;
 import org.infoglue.cms.controllers.kernel.impl.simple.RepositoryController;
 import org.infoglue.cms.controllers.kernel.impl.simple.SearchController;
+import org.infoglue.cms.controllers.kernel.impl.simple.SiteNodeController;
 import org.infoglue.cms.controllers.kernel.impl.simple.UserControllerProxy;
 import org.infoglue.cms.entities.content.ContentVO;
 import org.infoglue.cms.entities.content.ContentVersionVO;
@@ -56,7 +57,7 @@ import webwork.action.Action;
  * Action class for usecase SearchContentAction. Was better before but due to wanted support for multiple 
  * databases and lack of time I had to cut down on functionality - sorry Magnus. 
  *
- * @author Magnus Güvenal
+ * @author Magnus GÃ¼venal
  * @author Mattias Bogeblad
  */
 
@@ -221,7 +222,7 @@ public class SearchAction extends InfoGlueAbstractAction
 				}
 			}
 		}
-		
+
 		if(CmsPropertyHandler.getInternalSearchEngine().equalsIgnoreCase("lucene"))
 		{
 			allowCaseSensitive = false;
@@ -683,5 +684,37 @@ public class SearchAction extends InfoGlueAbstractAction
 	public String[] getRepositoryIdToSearch()
 	{
 		return this.repositoryIdToSearch;
+	}
+
+	public boolean getIsLuceneSearch()
+	{
+		return CmsPropertyHandler.getInternalSearchEngine().equalsIgnoreCase("lucene");
+	}
+
+	/**
+	 * Calls the right getPath version for the given <em>entity</em>.
+	 *
+	 * @throws NullPointerException if <em>entity</em> is null
+	 */
+	public String getEntityPath(BaseEntityVO entity) throws NullPointerException
+	{
+		try
+		{
+			if (entity instanceof ContentVersionVO)
+			{
+				return ContentController.getContentController().getContentPath(((ContentVersionVO)entity).getContentId(), false, true);
+			}
+			else if (entity instanceof SiteNodeVersionVO)
+			{
+				return SiteNodeController.getController().getSiteNodePath(((SiteNodeVersionVO)entity).getSiteNodeId(), false, true);
+			}
+		}
+		catch (Exception ex)
+		{
+			logger.warn("Error when getting path for entity in search result. Message: " + ex.getMessage());
+			logger.info("Error when getting path for entity in search result.", ex);
+		}
+
+		return "[" + entity.getId() + "]";
 	}
 }

--- a/src/java/org/infoglue/cms/controllers/kernel/impl/simple/ContentController.java
+++ b/src/java/org/infoglue/cms/controllers/kernel/impl/simple/ContentController.java
@@ -3270,7 +3270,7 @@ public class ContentController extends BaseController
 
 		ContentVO contentVO = ContentController.getContentController().getContentVOWithId(contentId, db);
 
-		sb.insert(0, contentVO.getName());
+		insertContentNameInPath(sb, contentVO);
 
 		while (contentVO.getParentContentId() != null)
 		{
@@ -3278,7 +3278,8 @@ public class ContentController extends BaseController
 
 			if (includeRootContent || contentVO.getParentContentId() != null)
 			{
-				sb.insert(0, contentVO.getName() + "/");
+				sb.insert(0, "/");
+				insertContentNameInPath(sb, contentVO);
 			}
 		}
 
@@ -3292,6 +3293,19 @@ public class ContentController extends BaseController
 		return sb.toString();
 	}
 
+	private void insertContentNameInPath(StringBuffer sb, ContentVO contentVO)
+	{
+		if (contentVO.getName() == null || contentVO.getName().equals(""))
+		{
+			sb.insert(0, "]");
+			sb.insert(0, contentVO.getId());
+			sb.insert(0, "[");
+		}
+		else
+		{
+			sb.insert(0, contentVO.getName());
+		}
+	}
 
 
 	public List<ContentVO> getRelatedContents(Database db, Integer contentId, Integer languageId, String attributeName, boolean useLanguageFallback) throws Exception

--- a/src/java/org/infoglue/cms/controllers/kernel/impl/simple/LuceneController.java
+++ b/src/java/org/infoglue/cms/controllers/kernel/impl/simple/LuceneController.java
@@ -2448,13 +2448,35 @@ public class LuceneController extends BaseController implements NotificationList
 	public String getContentPath(Integer contentId, Database db) throws Exception
 	{
 		StringBuffer sb = new StringBuffer();
-		
+
 		ContentVO contentVO = ContentController.getContentController().getContentVOWithId(contentId, db);
-		sb.insert(0, contentVO.getName());
+
+		if (contentVO.getName() == null || contentVO.getName().equals(""))
+		{
+			sb.insert(0, "]");
+			sb.insert(0, contentVO.getId());
+			sb.insert(0, "[");
+		}
+		else
+		{
+			sb.insert(0, contentVO.getName());
+		}
+
 		while(contentVO.getParentContentId() != null)
 		{
 			contentVO = ContentController.getContentController().getContentVOWithId(contentVO.getParentContentId(), db);
-			sb.insert(0, contentVO.getName() + "/");
+
+			sb.insert(0, "/");
+			if (contentVO.getName() == null || contentVO.getName().equals(""))
+			{
+				sb.insert(0, "]");
+				sb.insert(0, contentVO.getId());
+				sb.insert(0, "[");
+			}
+			else
+			{
+				sb.insert(0, contentVO.getName());
+			}
 		}
 		sb.insert(0, "/");
 		

--- a/src/webapp/cms/common/viewSearchResult.vm
+++ b/src/webapp/cms/common/viewSearchResult.vm
@@ -361,7 +361,12 @@
 										<tr>
 											<td>
 												<input type="checkbox" id="cv$contentVersionId" name="sel" value="$contentVersionId"/>
-												<a href="#" class="content" onclick="top.openUrlInWorkArea('ViewContent!V3.action?contentId=$contentVersionVO.contentId', '$contentVersionVO.contentName', 'content', '$ui.getString("tool.common.contentTabLabelPrefix")', 'ContentTool'); return false;">$contentVersionVO.contentName.replaceAll(' ', '&nbsp;') #*$this.getContentPath($contentVersionVO.contentId).replaceAll(' ', '&nbsp;')*#</a>
+												#if( $isLuceneSearch )
+													#set($contentPath = $contentVersionVO.getContentName().replaceAll(' ', '&nbsp;') )
+												#else
+													#set($contentPath = $this.getEntityPath($contentVersionVO).replaceAll(' ', '&nbsp;') )
+												#end
+												<a href="#" class="content" onclick="top.openUrlInWorkArea('ViewContent!V3.action?contentId=$contentVersionVO.contentId', '$contentVersionVO.contentName', 'content', '$ui.getString("tool.common.contentTabLabelPrefix")', 'ContentTool'); return false;">$contentPath</a>
 											</td>
 											<td>
 												<span>$this.getLanguageVO($contentVersionVO.languageId).name</span>
@@ -402,7 +407,12 @@
 										<tr>
 											<td>
 												<input type="checkbox" id="snv$siteNodeVersionId" name="selSiteNodeVersion" value="$siteNodeVersionId"/>
-												<a href="#" class="page" onclick="top.openUrlInWorkArea('ViewSiteNode.action?siteNodeId=$siteNodeVersionVO.siteNodeId', '$siteNodeVersionVO.siteNodeName', 'structure', '$ui.getString("tool.common.pageTabLabelPrefix")', 'StructureTool'); return false;">$siteNodeVersionVO.siteNodeName.replaceAll(' ', '&nbsp;') #*$this.getSiteNodePath($siteNodeVersionVO.siteNodeId)*#</a><br/>
+												#if( $isLuceneSearch )
+													#set($siteNodePath = $siteNodeVersionVO.siteNodeName.replaceAll(' ', '&nbsp;') )
+												#else
+													#set($siteNodePath = $this.getEntityPath($siteNodeVersionVO).replaceAll(' ', '&nbsp;') )
+												#end
+												<a href="#" class="page" onclick="top.openUrlInWorkArea('ViewSiteNode.action?siteNodeId=$siteNodeVersionVO.siteNodeId', '$siteNodeVersionVO.siteNodeName', 'structure', '$ui.getString("tool.common.pageTabLabelPrefix")', 'StructureTool'); return false;">$siteNodePath</a><br/>
 											</td>
 											<td>
 												<span>$siteNodeVersionVO.stateId</span>


### PR DESCRIPTION
Normally contents and pages always have names but it has been reported
that there are exceptions to this. Therefore getContentPath and
getSiteNodePath will now insert the entity ID (enclosed in brackets) if
there is no name.

SQL based search also shows content/page paths instead of names now.