### PR TITLE
Adds an asset optimization step to the dump asset method

### DIFF
--- a/src/java/org/infoglue/cms/applications/PresentationStrings_en.properties
+++ b/src/java/org/infoglue/cms/applications/PresentationStrings_en.properties
@@ -2154,3 +2154,5 @@ entity.ServerNode.property.doubleCheckComponentEditorRights.label=Double check c
 entity.ServerNode.property.optionalContentMode.label=Choose the mode for the WYSIWYG link dialog. What content should it be possible to amend to the selected page.
 entity.ServerNode.property.optionalContentHashSlotName.label=The name of the slot to look for HTML anchors in. Used when HTML Anchor is selected for content type in the link dialog.
 entity.ServerNode.property.optionalContentHashPropertyName.label=The name of the property to look for HTML anchors in. Used when HTML Anchor is selected for content type in the link dialog.
+
+entity.ServerNode.property.digitalAssetOptimizer.label=Provide a shell script that will be called when digital assets are stored on disk.

--- a/src/java/org/infoglue/cms/applications/PresentationStrings_fr.properties
+++ b/src/java/org/infoglue/cms/applications/PresentationStrings_fr.properties
@@ -2117,3 +2117,5 @@ entity.ServerNode.property.doubleCheckComponentEditorRights.label=Double check c
 entity.ServerNode.property.optionalContentMode.label=Choose the mode for the WYSIWYG link dialog. What content should it be possible to amend to the selected page.
 entity.ServerNode.property.optionalContentHashSlotName.label=The name of the slot to look for HTML anchors in. Used when HTML Anchor is selected for content type in the link dialog.
 entity.ServerNode.property.optionalContentHashPropertyName.label=The name of the property to look for HTML anchors in. Used when HTML Anchor is selected for content type in the link dialog.
+
+entity.ServerNode.property.digitalAssetOptimizer.label=Provide a shell script that will be called when digital assets are stored on disk.

--- a/src/java/org/infoglue/cms/applications/PresentationStrings_sv.properties
+++ b/src/java/org/infoglue/cms/applications/PresentationStrings_sv.properties
@@ -2126,3 +2126,5 @@ entity.ServerNode.property.doubleCheckComponentEditorRights.label=Double check c
 entity.ServerNode.property.optionalContentMode.label=Välj läge för WYSIWYG länkdialogen. Vilken typ av innehåll ska användaren kunna kompletter sidan med.
 entity.ServerNode.property.optionalContentHashSlotName.label=Slot-namnet där Infoglue ska leta efter HTML-ankaren i. Denna egenskap används enbart när länkdialogen använder HTML anchors.
 entity.ServerNode.property.optionalContentHashPropertyName.label=Egenskapen som används för att hitta innehåll att söka i efter HTML-ankare. Denna egenskap används enbart när länkdialogen använder HTML anchors.
+
+entity.ServerNode.property.digitalAssetOptimizer.label=Ange ett shell-skript som kommer anropas när bilagor sparas ut på disk.

--- a/src/java/org/infoglue/cms/applications/managementtool/actions/ViewServerNodePropertiesAction.java
+++ b/src/java/org/infoglue/cms/applications/managementtool/actions/ViewServerNodePropertiesAction.java
@@ -188,6 +188,7 @@ public class ViewServerNodePropertiesAction extends InfoGluePropertiesAbstractAc
 	    populate(ps, "errorUrl");
 	    populate(ps, "errorBusyUrl");
 	    populate(ps, "externalThumbnailGeneration");
+	    populate(ps, "digitalAssetOptimizer");
 	    populate(ps, "URIEncoding");
 	    populate(ps, "workflowEncoding");
 	    populate(ps, "formsEncoding");

--- a/src/java/org/infoglue/cms/controllers/kernel/impl/simple/DigitalAssetController.java
+++ b/src/java/org/infoglue/cms/controllers/kernel/impl/simple/DigitalAssetController.java
@@ -30,7 +30,6 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
-import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -54,7 +53,6 @@ import org.exolab.castor.jdo.Database;
 import org.exolab.castor.jdo.OQLQuery;
 import org.exolab.castor.jdo.QueryResults;
 import org.infoglue.cms.applications.common.VisualFormatter;
-import org.infoglue.cms.entities.content.Content;
 import org.infoglue.cms.entities.content.ContentVO;
 import org.infoglue.cms.entities.content.ContentVersion;
 import org.infoglue.cms.entities.content.ContentVersionVO;
@@ -65,10 +63,8 @@ import org.infoglue.cms.entities.content.impl.simple.DigitalAssetImpl;
 import org.infoglue.cms.entities.content.impl.simple.MediumContentVersionImpl;
 import org.infoglue.cms.entities.content.impl.simple.MediumDigitalAssetImpl;
 import org.infoglue.cms.entities.content.impl.simple.SmallDigitalAssetImpl;
-import org.infoglue.cms.entities.content.impl.simple.SmallStateContentImpl;
 import org.infoglue.cms.entities.content.impl.simple.SmallestContentVersionImpl;
 import org.infoglue.cms.entities.kernel.BaseEntityVO;
-import org.infoglue.cms.entities.management.GeneralOQLResult;
 import org.infoglue.cms.entities.management.GroupProperties;
 import org.infoglue.cms.entities.management.LanguageVO;
 import org.infoglue.cms.entities.management.RoleProperties;
@@ -80,10 +76,10 @@ import org.infoglue.cms.exception.SystemException;
 import org.infoglue.cms.security.InfoGluePrincipal;
 import org.infoglue.cms.util.CmsPropertyHandler;
 import org.infoglue.cms.util.graphics.ThumbnailGenerator;
+import org.infoglue.common.util.DigitalAssetOptimizer;
 import org.infoglue.deliver.controllers.kernel.impl.simple.LanguageDeliveryController;
 import org.infoglue.deliver.util.CacheController;
 import org.infoglue.deliver.util.HttpHelper;
-import org.infoglue.deliver.util.RequestAnalyser;
 import org.infoglue.deliver.util.Timer;
 
 /**
@@ -878,7 +874,7 @@ public class DigitalAssetController extends BaseController
 		if(digitalAssetVOList != null)
 		{
 			if(logger.isInfoEnabled())
-				logger.info("There was an cached digitalAssetVOList:" + digitalAssetVOList);
+				logger.info("There was a cached digitalAssetVOList:" + digitalAssetVOList);
 
 			return digitalAssetVOList;
 		}
@@ -955,7 +951,7 @@ public class DigitalAssetController extends BaseController
 		if(digitalAssetVOList != null)
 		{
 			if(logger.isInfoEnabled())
-				logger.info("There was an cached digitalAssetVOList:" + digitalAssetVOList);
+				logger.info("There was a cached digitalAssetVOList:" + digitalAssetVOList);
 			
 			return digitalAssetVOList;
 		}
@@ -2243,7 +2239,7 @@ public class DigitalAssetController extends BaseController
 		if(digitalAssetVO != null)
 		{
 			if(logger.isInfoEnabled())
-				logger.info("There was an cached digitalAssetVO:" + digitalAssetVO);
+				logger.info("There was a cached digitalAssetVO:" + digitalAssetVO);
 			
 			return digitalAssetVO;
 		}
@@ -2311,7 +2307,7 @@ public class DigitalAssetController extends BaseController
 		if(digitalAssetVO != null)
 		{
 			if(logger.isInfoEnabled())
-				logger.info("There was an cached digitalAssetVO:" + digitalAssetVO);
+				logger.info("There was a cached digitalAssetVO:" + digitalAssetVO);
 
 			return digitalAssetVO;
 		}
@@ -2400,7 +2396,7 @@ public class DigitalAssetController extends BaseController
 		if(!forceDump && outputFile.exists())
 		{
 			if(logger.isInfoEnabled())
-				logger.info("The file allready exists so we don't need to dump it again..");
+				logger.info("The file already exists so we don't need to dump it again..");
 
 			return true;
 		}
@@ -2454,6 +2450,15 @@ public class DigitalAssetController extends BaseController
 							if (forceDump)
 							{
 								outputFile.delete();
+							}
+							if (DigitalAssetOptimizer.hasDigitalAssetOptimizerEnabled())
+							{
+								File optimizedFile = DigitalAssetOptimizer.getInstance().optimizeDigitalAsset(digitalAssetVO, tmpOutputFile);
+								if (optimizedFile != null)
+								{
+									tmpOutputFile.delete();
+									tmpOutputFile = optimizedFile;
+								}
 							}
 							tmpOutputFile.renameTo(outputFile);
 							logger.info("Renamed to" + outputFile.getAbsolutePath() + "=" + outputFile.exists());
@@ -2537,7 +2542,7 @@ public class DigitalAssetController extends BaseController
 		if(outputFile.exists())
 		{
 			if(logger.isInfoEnabled())
-				logger.info("The file allready exists so we don't need to dump it again..");
+				logger.info("The file already exists so we don't need to dump it again..");
 		
 			return true;
 		}
@@ -2576,6 +2581,15 @@ public class DigitalAssetController extends BaseController
 				{
 					if(tmpOutputFile.length() == digitalAsset.getAssetFileSize())
 					{
+						if (DigitalAssetOptimizer.hasDigitalAssetOptimizerEnabled())
+						{
+							File optimizedFile = DigitalAssetOptimizer.getInstance().optimizeDigitalAsset(digitalAsset.getValueObject(), tmpOutputFile);
+							if (optimizedFile != null)
+							{
+								tmpOutputFile.delete();
+								tmpOutputFile = optimizedFile;
+							}
+						}
 						logger.info("written file:" + tmpOutputFile.getAbsolutePath() + " - renaming it to " + outputFile.getAbsolutePath());	
 						tmpOutputFile.renameTo(outputFile);
 						logger.info("Renamed to" + outputFile.getAbsolutePath() + "=" + outputFile.exists());

--- a/src/java/org/infoglue/cms/util/CmsPropertyHandler.java
+++ b/src/java/org/infoglue/cms/util/CmsPropertyHandler.java
@@ -3300,4 +3300,9 @@ public class CmsPropertyHandler
 		return Boolean.parseBoolean(value);
 	}
 
+	public static String getExternalImageOptimizer()
+	{
+		return getServerNodeProperty("digitalAssetOptimizer", true, null);
+	}
+
 }

--- a/src/java/org/infoglue/common/util/DigitalAssetOptimizer.java
+++ b/src/java/org/infoglue/common/util/DigitalAssetOptimizer.java
@@ -1,0 +1,190 @@
+package org.infoglue.common.util;
+
+import java.awt.Image;
+import java.io.File;
+import java.io.InputStream;
+import java.util.Arrays;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.log4j.Logger;
+import org.infoglue.cms.entities.content.DigitalAssetVO;
+import org.infoglue.cms.util.CmsPropertyHandler;
+
+public class DigitalAssetOptimizer
+{
+	private static Logger logger = Logger.getLogger(DigitalAssetOptimizer.class);
+	private static DigitalAssetOptimizer instance;
+
+	/* Public methods */
+
+	public File optimizeDigitalAsset(DigitalAssetVO assetVO, File file)
+	{
+		if (!canOptimizeDigitalAsset(assetVO))
+		{
+			return null;
+		}
+		try
+		{
+			File outputFile = new File(file.getAbsolutePath() + ".opti");
+			Image image = javax.imageio.ImageIO.read(file);
+			String[] args = new String[6];
+
+			args[0] = CmsPropertyHandler.getExternalImageOptimizer();
+			args[1] = "" + image.getWidth(null);
+			args[2] = "" + image.getHeight(null);
+			args[3] = assetVO.getAssetContentType();
+			args[4] = file.getAbsolutePath();
+			args[5] = outputFile.getAbsolutePath();
+
+			if (logger.isDebugEnabled())
+			{
+				logger.debug("Will optimize image <" + file.getAbsolutePath() + "> with command: " + Arrays.toString(args));
+			}
+
+			Process p = Runtime.getRuntime().exec(args);
+			p.waitFor();
+			if (p.exitValue() == 0 && outputFile.exists())
+			{
+				return outputFile;
+			}
+			else
+			{
+				logger.warn("Failed to optimize file. Status code: " + p.exitValue() + ", File exists: " + outputFile.exists());
+				if (logger.isDebugEnabled())
+				{
+					InputStream errorStream = p.getErrorStream();
+					if (errorStream == null)
+					{
+						logger.debug("Got no error stream for image optimization error.");
+					}
+					else
+					{
+						logger.debug("Error stream for image optimization error: " + IOUtils.toString(errorStream));
+					}
+				}
+				return null;
+			}
+		}
+		catch (Exception ex)
+		{
+			logger.error("Error optimizing image. Message: " + ex.getMessage());
+			logger.warn("Error optimizing image.", ex);
+			return null;
+		}
+	}
+
+	/**
+	 * Determine if the system can optimize the given DigitalAsset.
+	 *
+	 * @param digitalAssetVO
+	 * @return true if calling {@linkplain #optimizeImage(DigitalAssetVO, File)} would optimize the image, false otherwise.
+	 */
+	private boolean canOptimizeDigitalAsset(DigitalAssetVO digitalAssetVO)
+	{
+		if (!hasDigitalAssetOptimizerEnabled())
+		{
+			return false;
+		}
+		// TODO property for customizing
+		String validContentTypes = "image/jpeg,image/jpg,image/png";
+		return validContentTypes.indexOf(digitalAssetVO.getAssetContentType()) > -1;
+	}
+	
+	public static boolean hasDigitalAssetOptimizerEnabled()
+	{
+		if (logger.isDebugEnabled())
+		{
+			logger.debug("Has image optimizer: " + CmsPropertyHandler.getExternalImageOptimizer());
+		}
+		return CmsPropertyHandler.getExternalImageOptimizer() != null;
+	}
+
+	/* Singleton methods */
+	
+	private static synchronized void setupInstance()
+	{
+		if (instance == null)
+		{
+			instance = new DigitalAssetOptimizer();
+		}
+	}
+	
+	public static DigitalAssetOptimizer getInstance()
+	{
+		if (instance == null)
+		{
+			setupInstance();
+		}
+		return instance;
+	}
+}
+
+/*
+public static boolean isAssetImage(DigitalAssetVO assetVO)
+	{
+		// TODO property for customizing
+		String validContentTypes = "image/jpeg,image/jpg,image/png";
+		return validContentTypes.indexOf(assetVO.getAssetContentType()) > -1;
+	}
+	
+	public static boolean hasImageOptimizedEnabled()
+	{
+		if (logger.isDebugEnabled())
+		{
+			logger.debug("Has image optimized: " + CmsPropertyHandler.getExternalImageOptimizer());
+		}
+		return CmsPropertyHandler.getExternalImageOptimizer() != null;
+	}
+	
+	public static File optimizeImage(DigitalAssetVO assetVO, File file)
+	{
+		try
+		{
+			File outputFile = new File(file.getAbsolutePath() + ".opti");
+			Image image = javax.imageio.ImageIO.read(file);
+			String[] args = new String[6];
+
+			args[0] = CmsPropertyHandler.getExternalImageOptimizer();
+			args[1] = "" + image.getWidth(null);
+			args[2] = "" + image.getHeight(null);
+			args[3] = assetVO.getAssetContentType();
+			args[4] = file.getAbsolutePath();
+			args[5] = outputFile.getAbsolutePath();
+
+			if (logger.isDebugEnabled())
+			{
+				logger.debug("Will optimize image <" + file.getAbsolutePath() + "> with command: " + Arrays.toString(args));
+			}
+
+			Process p = Runtime.getRuntime().exec(args);
+			p.waitFor();
+			if (p.exitValue() == 0 && outputFile.exists())
+			{
+				return outputFile;
+			}
+			else
+			{
+				logger.warn("Failed to optimize file. Status code: " + p.exitValue() + ", File exists: " + outputFile.exists());
+				if (logger.isDebugEnabled())
+				{
+					InputStream errorStream = p.getErrorStream();
+					if (errorStream == null)
+					{
+						logger.debug("Got no error stream for image optimization error.");
+					}
+					else
+					{
+						logger.debug("Error stream for image optimization error: " + IOUtils.toString(errorStream));
+					}
+				}
+				return null;
+			}
+		}
+		catch (Exception ex)
+		{
+			logger.error("Error optimizing image. Message: " + ex.getMessage());
+			logger.warn("Error optimizing image.", ex);
+			return null;
+		}	
+	}
+*/

--- a/src/java/org/infoglue/deliver/controllers/kernel/impl/simple/DigitalAssetDeliveryController.java
+++ b/src/java/org/infoglue/deliver/controllers/kernel/impl/simple/DigitalAssetDeliveryController.java
@@ -54,6 +54,7 @@ import org.infoglue.cms.entities.management.Repository;
 import org.infoglue.cms.exception.SystemException;
 import org.infoglue.cms.util.CmsPropertyHandler;
 import org.infoglue.cms.util.graphics.ThumbnailGenerator;
+import org.infoglue.common.util.DigitalAssetOptimizer;
 import org.infoglue.deliver.applications.databeans.DeliveryContext;
 import org.infoglue.deliver.controllers.kernel.URLComposer;
 import org.infoglue.deliver.util.HttpHelper;
@@ -298,8 +299,8 @@ public class DigitalAssetDeliveryController extends BaseDeliveryController
 	}
 
 	/**
-	 * This is the basic way of getting an asset-url for a digital asset. 
-	 * If the asset is cached on disk it returns that path imediately it's ok - otherwise it dumps it fresh.
+	 * This is the basic way of getting an asset-URL for a digital asset. 
+	 * If the asset is cached on disk it returns that path immediately it's OK - otherwise it dumps it fresh.
 	 */
 
 	public String getAssetUrl(DigitalAsset digitalAsset, Repository repository, DeliveryContext deliveryContext) throws SystemException, Exception
@@ -515,7 +516,7 @@ public class DigitalAssetDeliveryController extends BaseDeliveryController
 		if(outputFile.exists())
 		{
 			if(logger.isInfoEnabled())
-				logger.info("The file allready exists so we don't need to dump it again..");
+				logger.info("The file already exists so we don't need to dump it again. File name: " + fileName);
 		
 			return outputFile;
 		}
@@ -648,6 +649,15 @@ public class DigitalAssetDeliveryController extends BaseDeliveryController
 				}
 				else
 				{
+					if (DigitalAssetOptimizer.hasDigitalAssetOptimizerEnabled())
+					{
+						File optimizedFile = DigitalAssetOptimizer.getInstance().optimizeDigitalAsset(digitalAssetVO, tmpOutputFile);
+						if (optimizedFile != null)
+						{
+							tmpOutputFile.delete();
+							tmpOutputFile = optimizedFile;
+						}
+					}
 					logger.info("written file:" + tmpOutputFile.length() + " - renaming it to " + outputFile.getAbsolutePath());	
 					tmpOutputFile.renameTo(outputFile);
 					logger.info("Time for renaming file " + timer.getElapsedTime());
@@ -717,6 +727,15 @@ public class DigitalAssetDeliveryController extends BaseDeliveryController
 			}
 			else
 			{
+				if (DigitalAssetOptimizer.hasDigitalAssetOptimizerEnabled())
+				{
+					File optimizedFile = DigitalAssetOptimizer.getInstance().optimizeDigitalAsset(digitalAsset.getValueObject(), tmpOutputFile);
+					if (optimizedFile != null)
+					{
+						tmpOutputFile.delete();
+						tmpOutputFile = optimizedFile;
+					}
+				}
 				logger.info("written file:" + tmpOutputFile.length() + " - renaming it to " + outputFile.getAbsolutePath());	
 				tmpOutputFile.renameTo(outputFile);
 				logger.info("Time for renaming file " + timer.getElapsedTime());
@@ -733,7 +752,7 @@ public class DigitalAssetDeliveryController extends BaseDeliveryController
 
  	/**
    	 * This method checks if the given file exists on disk. If it does it's ignored because
-   	 * that means that the file is allready cached on the server. If not we take out the stream from the 
+   	 * that means that the file is already cached on the server. If not we take out the stream from the 
    	 * digitalAsset-object and dumps it.
    	 */
    	
@@ -744,7 +763,7 @@ public class DigitalAssetDeliveryController extends BaseDeliveryController
 		File outputFile = new File(filePath + File.separator + fileName);
 		if(outputFile.exists() && outputFile.length() > 0)
 		{
-			//logger.info("The file allready exists so we don't need to dump it again..");
+			//logger.info("The file already exists so we don't need to dump it again..");
 			return outputFile;
 		}
 		

--- a/src/webapp/cms/managementtool/viewServerNodeProperties.vm
+++ b/src/webapp/cms/managementtool/viewServerNodeProperties.vm
@@ -557,6 +557,7 @@
 				#yesNoDropDownWithInheritCSS("ServerNode.property.useFreeMarker" "useFreeMarker" "$this.getPropertyValue('useFreeMarker')" "$!cmsPH.useFreeMarker")
 				#editPropertyFieldCSS("ServerNode.property.errorBusyUrl" "errorBusyUrl" "$this.getPropertyValue('errorBusyUrl')" "51" "$!serverNodeId" "$!cmsPH.errorBusyUrl")
 				#editPropertyFieldCSS("ServerNode.property.externalThumbnailGeneration" "externalThumbnailGeneration" "$this.getPropertyValue('externalThumbnailGeneration')" "51" "$!serverNodeId" "$!cmsPH.externalThumbnailGeneration")
+				#editPropertyFieldCSS("ServerNode.property.digitalAssetOptimizer" "digitalAssetOptimizer" "$this.getPropertyValue('digitalAssetOptimizer')" "51" "$!serverNodeId" "$!cmsPH.digitalAssetOptimizer")
 				#yesNoDropDownWithInheritCSS("ServerNode.property.enablePortal" "enablePortal" "$this.getPropertyValue('enablePortal')" "$!cmsPH.enablePortal")
 				#editPropertyFieldCSS("ServerNode.property.portletBase" "portletBase" "$this.getPropertyValue('portletBase')" "51" "$!serverNodeId" "$!cmsPH.portletBase")
 				#yesNoDropDownWithInheritCSS("ServerNode.property.logDatabaseMessages" "logDatabaseMessages" "$this.getPropertyValue('logDatabaseMessages')" "$!cmsPH.logDatabaseMessages")


### PR DESCRIPTION
When an asset is to be dump to disk it can now be passed to a OS level
executable before the dump is finished. The executable can do anything but
is expected to perform optimization (e.g. ImageMagick) on the asset. Only
PNGs and JPGs can use the new function as this time.